### PR TITLE
Fix for FlxExtendedSprite dragging.

### DIFF
--- a/flixel/addons/display/FlxExtendedSprite.hx
+++ b/flixel/addons/display/FlxExtendedSprite.hx
@@ -562,14 +562,14 @@ class FlxExtendedSprite extends FlxSprite
 		if (_allowHorizontalDrag == true)
 		{
 			#if !FLX_NO_MOUSE
-			x = Math.floor(FlxG.mouse.x) - _dragOffsetX;
+			x = Math.floor(FlxG.mouse.screenX + scrollFactor.x * (FlxG.mouse.x - FlxG.mouse.screenX)) - _dragOffsetX;
 			#end
 		}
 		
 		if (_allowVerticalDrag == true)
 		{
 			#if !FLX_NO_MOUSE
-			y = Math.floor(FlxG.mouse.y) - _dragOffsetY;
+			y = Math.floor(FlxG.mouse.screenY + scrollFactor.y * (FlxG.mouse.y - FlxG.mouse.screenY)) - _dragOffsetY;
 			#end
 		}
 		
@@ -680,8 +680,8 @@ class FlxExtendedSprite extends FlxSprite
 		#if !FLX_NO_MOUSE
 		if (_dragFromPoint == false)
 		{
-			_dragOffsetX = Math.floor(Math.floor(FlxG.mouse.x) - x);
-			_dragOffsetY = Math.floor(Math.floor(FlxG.mouse.y) - y);
+			_dragOffsetX = Math.floor(FlxG.mouse.screenX + scrollFactor.x * (FlxG.mouse.x - FlxG.mouse.screenX) - x);
+			_dragOffsetY = Math.floor(FlxG.mouse.screenY + scrollFactor.y * (FlxG.mouse.y - FlxG.mouse.screenY) - y);
 		}
 		else
 		{


### PR DESCRIPTION
This is my first ever contribution to a project on Github so please be gentle.

Updated the get_mouseOver() function to check the scrollFactor for each dimension independently. I used inline if statements because I wasn't sure if temporary variables would have been a bad thing.

Please shout at me if I have set anything on fire.
