### PR TITLE
Fix Tiled for uncompressed maps

### DIFF
--- a/flixel/addons/editors/tiled/TiledLayer.hx
+++ b/flixel/addons/editors/tiled/TiledLayer.hx
@@ -81,11 +81,8 @@ class TiledLayer
 			
 			if (compressed)
 			{
-				#if js
-				// FIXME: Zlib doesn't exists in js so it won't work
-				throw "HTML5 doesn't support compressed data!";
-				//untyped __js__('var inflated = new Zlib.Inflate(chunk)'); 
-				//result = untyped __js__('inflated.decompress()');
+				#if (js && !format)
+				throw "HTML5 doesn't support compressed data! Use Base64 (uncompressed) when you save the map or install the library 'format' and use it";
 				#else
 				result.uncompress();
 				#end


### PR DESCRIPTION
Also, throw an exception if the target is html5 and the map layers are compressed with Zlib compression. But if you use the [format](https://github.com/HaxeFoundation/format) library you can have compressed data in html5.
