### PR TITLE
updating flixel imports to use 'org.' prefix

### DIFF
--- a/flixel/addons/display/FlxExtendedSprite.hx
+++ b/flixel/addons/display/FlxExtendedSprite.hx
@@ -1,12 +1,12 @@
 package flixel.addons.display;
 
 import flixel.addons.plugin.FlxMouseControl;
-import flixel.FlxG;
-import flixel.FlxSprite;
-import flixel.util.FlxCollision;
-import flixel.util.FlxMath;
-import flixel.util.FlxPoint;
-import flixel.util.FlxRect;
+import org.flixel.FlxG;
+import org.flixel.FlxSprite;
+import org.flixel.util.FlxCollision;
+import org.flixel.util.FlxMath;
+import org.flixel.util.FlxPoint;
+import org.flixel.util.FlxRect;
 
 /**
  * An enhanced FlxSprite that is capable of receiving mouse clicks, being dragged and thrown, mouse springs, gravity and other useful things
@@ -99,7 +99,7 @@ class FlxExtendedSprite extends FlxSprite
 	 * By default the spring attaches to the top left of the sprite. To change this location provide a y offset (in pixels)
 	 */
 	public var springOffsetY:Int;
-	
+
 	#if !FLX_NO_MOUSE
 	/**
 	 * Function called when the mouse is pressed down on this sprite. Function is passed these parameters: obj:FlxExtendedSprite, x:int, y:int
@@ -131,21 +131,21 @@ class FlxExtendedSprite extends FlxSprite
 	 */
 	public var hasMouseSpring:Bool = false;
 	#end
-	
+
 	private var _snapOnDrag:Bool = false;
 	private var _snapOnRelease:Bool = false;
 	private var _snapX:Int;
 	private var _snapY:Int;
-	
+
 	private var _clickOnRelease:Bool = false;
 	private var _clickPixelPerfect:Bool = false;
 	private var _clickPixelPerfectAlpha:Int;
 	private var _clickCounter:Int = 0;
-	
-	private var _rect:FlxRect; 
+
+	private var _rect:FlxRect;
 	private var _throwXFactor:Int;
 	private var _throwYFactor:Int;
-	
+
 	private var _dragPixelPerfect:Bool;
 	private var _dragPixelPerfectAlpha:Int;
 	private var _dragOffsetX:Int;
@@ -153,11 +153,11 @@ class FlxExtendedSprite extends FlxSprite
 	private var _dragFromPoint:Bool;
 	private var _allowHorizontalDrag:Bool = true;
 	private var _allowVerticalDrag:Bool = true;
-	
+
 	/**
 	 * Creates a white 8x8 square <code>FlxExtendedSprite</code> at the specified position.
 	 * Optionally can load a simple, one-frame graphic instead.
-	 * 
+	 *
 	 * @param	X				The initial X position of the sprite.
 	 * @param	Y				The initial Y position of the sprite.
 	 * @param	SimpleGraphic	The graphic you want to display (OPTIONAL - for simple stuff only, do NOT use for animated images!).
@@ -165,15 +165,15 @@ class FlxExtendedSprite extends FlxSprite
 	public function new(X:Float = 0, Y:Float = 0, ?SimpleGraphic:Dynamic)
 	{
 		_rect = new FlxRect();
-		
+
 		super(X, Y, SimpleGraphic);
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	/**
 	 * Allow this Sprite to receive mouse clicks, the total number of times this sprite is clicked is stored in this.clicks<br>
 	 * You can add callbacks via mousePressedCallback and mouseReleasedCallback
-	 * 
+	 *
 	 * @param	OnRelease			Register the click when the mouse is pressed down (false) or when it's released (true). Note that callbacks still fire regardless of this setting.
 	 * @param	PixelPerfect		If true it will use a pixel perfect test to see if you clicked the Sprite. False uses the bounding box.
 	 * @param	AlphaThreshold		If using pixel perfect collision this specifies the alpha level from 0 to 255 above which a collision is processed (default 255)
@@ -184,9 +184,9 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			throw "FlxExtendedSprite.enableMouseClicks called but FlxMouseControl plugin not activated";
 		}
-		
+
 		clickable = true;
-		
+
 		_clickOnRelease = OnRelease;
 		_clickPixelPerfect = PixelPerfect;
 		_clickPixelPerfectAlpha = AlphaThreshold;
@@ -202,25 +202,25 @@ class FlxExtendedSprite extends FlxSprite
 		mousePressedCallback = null;
 		mouseReleasedCallback = null;
 	}
-	
+
 	/**
 	 * The number of clicks this item has received. Usually you'd only set it to zero.
 	 */
 	public var clicks(get, set):Int;
-	
+
 	private function get_clicks():Int
 	{
 		return _clickCounter;
 	}
-	
+
 	private function set_clicks(NewValue:Int):Int
 	{
 		return _clickCounter = NewValue;
 	}
-	
+
 	/**
 	 * Make this Sprite draggable by the mouse. You can also optionally set mouseStartDragCallback and mouseStopDragCallback
-	 * 
+	 *
 	 * @param	LockCenter			If false the Sprite will drag from where you click it. If true it will center itself to the tip of the mouse pointer.
 	 * @param	PixelPerfect		If true it will use a pixel perfect test to see if you clicked the Sprite. False uses the bounding box.
 	 * @param	AlphaThreshold		If using pixel perfect collision this specifies the alpha level from 0 to 255 above which a collision is processed (default 255)
@@ -233,26 +233,26 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			throw "FlxExtendedSprite.enableMouseDrag called but FlxMouseControl plugin not activated";
 		}
-		
+
 		draggable = true;
-		
+
 		_dragFromPoint = LockCenter;
 		_dragPixelPerfect = PixelPerfect;
 		_dragPixelPerfectAlpha = AlphaThreshold;
-		
+
 		if (BoundsRect != null)
 		{
 			boundsRect = BoundsRect;
 		}
-		
+
 		if (BoundsSprite != null)
 		{
 			boundsSprite = BoundsSprite;
 		}
 	}
-	
+
 	/**
-	 * Stops this sprite from being able to be dragged. If it is currently the target of 
+	 * Stops this sprite from being able to be dragged. If it is currently the target of
 	 * an active drag it will be stopped immediately. Also disables any set callbacks.
 	 */
 	public function disableMouseDrag():Void
@@ -262,17 +262,17 @@ class FlxExtendedSprite extends FlxSprite
 			FlxMouseControl.dragTarget = null;
 			FlxMouseControl.isDragging = false;
 		}
-		
+
 		isDragged = false;
 		draggable = false;
-		
+
 		mouseStartDragCallback = null;
 		mouseStopDragCallback = null;
 	}
-	
+
 	/**
 	 * Make this Sprite throwable by the mouse. The sprite is thrown only when the mouse button is released.
-	 * 
+	 *
 	 * @param	FactorX		The sprites velocity is set to FlxMouseControl.speedX * xFactor. Try a value around 50+
 	 * @param	FactorY		The sprites velocity is set to FlxMouseControl.speedY * yFactor. Try a value around 50+
 	 */
@@ -282,11 +282,11 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			throw "FlxExtendedSprite.enableMouseThrow called but FlxMouseControl plugin not activated";
 		}
-		
+
 		throwable = true;
 		_throwXFactor = FactorX;
 		_throwYFactor = FactorY;
-		
+
 		if (clickable == false && draggable == false)
 		{
 			clickable = true;
@@ -304,7 +304,7 @@ class FlxExtendedSprite extends FlxSprite
 	/**
 	 * Make this Sprite snap to the given grid either during drag or when it's released.
 	 * For example 16x16 as the snapX and snapY would make the sprite snap to every 16 pixels.
-	 * 
+	 *
 	 * @param	SnapX		The width of the grid cell in pixels
 	 * @param	SnapY		The height of the grid cell in pixels
 	 * @param	OnDrag		If true the sprite will snap to the grid while being dragged
@@ -330,24 +330,24 @@ class FlxExtendedSprite extends FlxSprite
 	/**
 	 * Adds a simple spring between the mouse and this Sprite. The spring can be activated either when the mouse is pressed (default), or enabled all the time.
 	 * Note that nearly always the Spring will over-ride any other motion setting the sprite has (like velocity or gravity)
-	 * 
+	 *
 	 * @param	OnPressed			True if the spring should only be active when the mouse is pressed down on this sprite
 	 * @param	RetainVelocity		True to retain the velocity of the spring when the mouse is released, or false to clear it
 	 * @param	Tension				The tension of the spring, smaller numbers create springs closer to the mouse pointer
 	 * @param	Friction			The friction applied to the spring as it moves
 	 * @param	Gravity				The gravity controls how far "down" the spring hangs (use a negative value for it to hang up!)
 	 * @return	The <code>FlxMouseSpring</code> object if you wish to perform further chaining on it. Also available via FlxExtendedSprite.mouseSpring
-	 */ 
+	 */
 	public function enableMouseSpring(OnPressed:Bool = true, RetainVelocity:Bool = false, Tension:Float = 0.1, Friction:Float = 0.95, Gravity:Float = 0):FlxMouseSpring
 	{
 		if (FlxG.plugins.get(FlxMouseControl) == null)
 		{
 			throw "FlxExtendedSprite.enableMouseSpring called but FlxMouseControl plugin not activated";
 		}
-		
+
 		hasMouseSpring = true;
 		springOnPressed = OnPressed;
-		
+
 		if (mouseSpring == null)
 		{
 			mouseSpring = new FlxMouseSpring(this, RetainVelocity, Tension, Friction, Gravity);
@@ -358,15 +358,15 @@ class FlxExtendedSprite extends FlxSprite
 			mouseSpring.friction = Friction;
 			mouseSpring.gravity = Gravity;
 		}
-		
+
 		if (clickable == false && draggable == false)
 		{
 			clickable = true;
 		}
-		
+
 		return mouseSpring;
 	}
-	
+
 	/**
 	 * Stops the sprite to mouse spring from being active
 	 */
@@ -376,10 +376,10 @@ class FlxExtendedSprite extends FlxSprite
 		mouseSpring = null;
 	}
 	#end
-	
+
 	/**
 	* Restricts this sprite to drag movement only on the given axis. Note: If both are set to false the sprite will never move!
-	 * 
+	 *
 	 * @param	AllowHorizontalDrag		To enable the sprite to be dragged horizontally set to true, otherwise false
 	 * @param	AllowVerticalDrag		To enable the sprite to be dragged vertically set to true, otherwise false
 	 */
@@ -388,27 +388,27 @@ class FlxExtendedSprite extends FlxSprite
 		_allowHorizontalDrag = AllowHorizontalDrag;
 		_allowVerticalDrag = AllowVerticalDrag;
 	}
-	
+
 	/**
 	 * The spring x coordinate in game world space. Consists of <code>sprite.x + springOffsetX</code>
 	 */
 	public var springX(get, never):Int;
-	
+
 	private function get_springX():Int
 	{
 		return Math.floor(x + springOffsetX);
 	}
-	
+
 	/**
 	 * The spring y coordinate in game world space. Consists of <code>sprite.y + springOffsetY</code>
 	 */
 	public var springY(get, never):Int;
-	
+
 	private function get_springY():Int
 	{
 		return Math.floor(y + springOffsetY);
 	}
-	
+
 	/**
 	 * Core update loop
 	 */
@@ -419,17 +419,17 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			updateDrag();
 		}
-		
+
 		if (isPressed == false && FlxG.mouse.justPressed)
 		{
 			checkForClick();
 		}
-		
+
 		if (hasGravity == true)
 		{
 			updateGravity();
 		}
-		
+
 		if (hasMouseSpring == true)
 		{
 			if (springOnPressed == false)
@@ -449,17 +449,17 @@ class FlxExtendedSprite extends FlxSprite
 			}
 		}
 		#end
-		
+
 		super.update();
 	}
-	
+
 	/**
 	 * Called by update, applies friction if the sprite has gravity to stop jittery motion when slowing down
 	 */
 	private function updateGravity():Void
 	{
 		//	A sprite can have horizontal and/or vertical gravity in each direction (positiive / negative)
-		
+
 		//	First let's check the x movement
 		if (velocity.x != 0)
 		{
@@ -469,7 +469,7 @@ class FlxExtendedSprite extends FlxSprite
 				if ((touching & FlxObject.WALL) != 0)
 				{
 					drag.y = frictionY;
-					
+
 					if ((wasTouching & FlxObject.WALL) == 0)
 					{
 						if (velocity.x < toleranceX)
@@ -490,7 +490,7 @@ class FlxExtendedSprite extends FlxSprite
 				{
 					//	Stop them sliding like on ice
 					drag.y = frictionY;
-					
+
 					if ((wasTouching & FlxObject.WALL) == 0)
 					{
 						if (velocity.x > -toleranceX)
@@ -505,7 +505,7 @@ class FlxExtendedSprite extends FlxSprite
 				}
 			}
 		}
-		
+
 		//	Now check the y movement
 		if (velocity.y != 0)
 		{
@@ -515,7 +515,7 @@ class FlxExtendedSprite extends FlxSprite
 				if ((touching & FlxObject.CEILING) != 0)
 				{
 					drag.x = frictionX;
-					
+
 					if ((wasTouching & FlxObject.CEILING) == 0)
 					{
 						if (velocity.y < toleranceY)
@@ -536,7 +536,7 @@ class FlxExtendedSprite extends FlxSprite
 				{
 					//	Stop them sliding like on ice
 					drag.x = frictionX;
-					
+
 					if ((wasTouching & FlxObject.FLOOR) == 0)
 					{
 						if (velocity.y > -toleranceY)
@@ -552,7 +552,7 @@ class FlxExtendedSprite extends FlxSprite
 			}
 		}
 	}
-	
+
 	/**
 	 * Updates the Mouse Drag on this Sprite.
 	 */
@@ -565,14 +565,14 @@ class FlxExtendedSprite extends FlxSprite
 			x = Math.floor(FlxG.mouse.screenX + scrollFactor.x * (FlxG.mouse.x - FlxG.mouse.screenX)) - _dragOffsetX;
 			#end
 		}
-		
+
 		if (_allowVerticalDrag == true)
 		{
 			#if !FLX_NO_MOUSE
 			y = Math.floor(FlxG.mouse.screenY + scrollFactor.y * (FlxG.mouse.y - FlxG.mouse.screenY)) - _dragOffsetY;
 			#end
 		}
-		
+
 		if (boundsRect != null)
 		{
 			checkBoundsRect();
@@ -582,16 +582,16 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			checkBoundsSprite();
 		}
-		
+
 		if (_snapOnDrag)
 		{
 			x = (Math.floor(x / _snapX) * _snapX);
 			y = (Math.floor(y / _snapY) * _snapY);
 		}
 	}
-	
+
 	/**
-	 * Checks if the mouse is over this sprite and pressed, then does a pixel 
+	 * Checks if the mouse is over this sprite and pressed, then does a pixel
 	 * perfect check if needed and adds it to the FlxMouseControl check stack.
 	 */
 	private function checkForClick():Void
@@ -605,13 +605,13 @@ class FlxExtendedSprite extends FlxSprite
 				FlxMouseControl.addToStack(this);
 				return;
 			}
-			
+
 			if (_clickPixelPerfect && FlxCollision.pixelPerfectPointCheck(Math.floor(FlxG.mouse.x), Math.floor(FlxG.mouse.y), this, _clickPixelPerfectAlpha))
 			{
 				FlxMouseControl.addToStack(this);
 				return;
 			}
-			
+
 			if (_dragPixelPerfect && FlxCollision.pixelPerfectPointCheck(Math.floor(FlxG.mouse.x), Math.floor(FlxG.mouse.y), this, _dragPixelPerfectAlpha))
 			{
 				FlxMouseControl.addToStack(this);
@@ -620,7 +620,7 @@ class FlxExtendedSprite extends FlxSprite
 		}
 		#end
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	/**
 	 * Called by FlxMouseControl when this sprite is clicked. Should not usually be called directly.
@@ -628,55 +628,55 @@ class FlxExtendedSprite extends FlxSprite
 	public function mousePressedHandler():Void
 	{
 		isPressed = true;
-		
+
 		if (clickable == true && _clickOnRelease == false)
 		{
 			_clickCounter++;
 		}
-		
+
 		if (mousePressedCallback != null)
 		{
 			mousePressedCallback(this, mouseX, mouseY);
 		}
 	}
-	
+
 	/**
 	 * Called by FlxMouseControl when this sprite is released from a click. Should not usually be called directly.
 	 */
 	public function mouseReleasedHandler():Void
 	{
 		isPressed = false;
-		
+
 		if (isDragged == true)
 		{
 			stopDrag();
 		}
-		
+
 		if (clickable == true && _clickOnRelease == true)
 		{
 			_clickCounter++;
 		}
-		
+
 		if (throwable == true)
 		{
 			velocity.x = FlxMouseControl.speedX * _throwXFactor;
 			velocity.y = FlxMouseControl.speedY * _throwYFactor;
 		}
-		
+
 		if (mouseReleasedCallback != null)
 		{
 			mouseReleasedCallback(this, mouseX, mouseY);
 		}
 	}
 	#end
-	
+
 	/**
 	 * Called by FlxMouseControl when Mouse Drag starts on this Sprite. Should not usually be called directly.
 	 */
 	public function startDrag():Void
 	{
 		isDragged = true;
-		
+
 		#if !FLX_NO_MOUSE
 		if (_dragFromPoint == false)
 		{
@@ -691,7 +691,7 @@ class FlxExtendedSprite extends FlxSprite
 		}
 		#end
 	}
-	
+
 	/**
 	 * Bounds Rect check for the sprite drag
 	 */
@@ -705,7 +705,7 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			x = boundsRect.right - width;
 		}
-		
+
 		if (y < boundsRect.top)
 		{
 			y = boundsRect.top;
@@ -715,7 +715,7 @@ class FlxExtendedSprite extends FlxSprite
 			y = boundsRect.bottom - height;
 		}
 	}
-	
+
 	/**
 	 * Parent Sprite Bounds check for the sprite drag
 	 */
@@ -729,7 +729,7 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			x = (boundsSprite.x + boundsSprite.width) - width;
 		}
-		
+
 		if (y < boundsSprite.y)
 		{
 			y = boundsSprite.y;
@@ -739,25 +739,25 @@ class FlxExtendedSprite extends FlxSprite
 			y = (boundsSprite.y + boundsSprite.height) - height;
 		}
 	}
-	
+
 	/**
 	 * Called by FlxMouseControl when Mouse Drag is stopped on this Sprite. Should not usually be called directly.
 	 */
 	public function stopDrag():Void
 	{
 		isDragged = false;
-		
+
 		if (_snapOnRelease)
 		{
 			x = (Math.floor(x / _snapX) * _snapX);
 			y = (Math.floor(y / _snapY) * _snapY);
 		}
 	}
-	
+
 	/**
 	 * Gravity can be applied to the sprite, pulling it in any direction. Gravity is given in pixels per second and is applied as acceleration.
 	 * If you don't want gravity for a specific direction pass a value of zero. To cancel it entirely pass both values as zero.
-	 * 
+	 *
 	 * @param	GravityX	A positive value applies gravity dragging the sprite to the right. A negative value drags the sprite to the left. Zero disables horizontal gravity.
 	 * @param	GravityY	A positive value applies gravity dragging the sprite down. A negative value drags the sprite up. Zero disables vertical gravity.
 	 * @param	FrictionX	The amount of friction applied to the sprite if it hits a wall. Allows it to come to a stop without constantly jittering.
@@ -768,25 +768,25 @@ class FlxExtendedSprite extends FlxSprite
 	public function setGravity(GravityX:Int, GravityY:Int, FrictionX:Float = 500, FrictionY:Float = 500, ToleranceX:Float = 10, ToleranceY:Float = 10):Void
 	{
 		hasGravity = true;
-		
+
 		gravityX = GravityX;
 		gravityY = GravityY;
-		
+
 		frictionX = FrictionX;
 		frictionY = FrictionY;
-		
+
 		toleranceX = ToleranceX;
 		toleranceY = ToleranceY;
-		
+
 		if (GravityX == 0 && GravityY == 0)
 		{
 			hasGravity = false;
 		}
-		
+
 		acceleration.x = GravityX;
 		acceleration.y = GravityY;
 	}
-	
+
 	/**
 	 * Switches the gravity applied to the sprite. If gravity was +400 Y (pulling them down) this will swap it to -400 Y (pulling them up)
 	 * To reset call flipGravity again
@@ -798,36 +798,36 @@ class FlxExtendedSprite extends FlxSprite
 			gravityX = -gravityX;
 			acceleration.x = gravityX;
 		}
-		
+
 		if (!Math.isNaN(gravityY) && gravityY != 0)
 		{
 			gravityY = -gravityY;
 			acceleration.y = gravityY;
 		}
 	}
-	
+
 	/**
 	 * A <code>FlxPoint</code> consisting of this sprites world x/y coordinates
 	 */
 	public var point(get, set):FlxPoint;
-	
+
 	private function get_point():FlxPoint
 	{
 		return _point;
 	}
-	
+
 	private function set_point(NewPoint:FlxPoint):FlxPoint
 	{
 		return _point = NewPoint;
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	/**
-	 * Return true if the mouse is over this Sprite, otherwise false. Only takes the Sprites bounding box into consideration and does not check if there 
+	 * Return true if the mouse is over this Sprite, otherwise false. Only takes the Sprites bounding box into consideration and does not check if there
 	 * are other sprites potentially on-top of this one. Check the value of this.isPressed if you need to know if the mouse is currently clicked on this sprite.
 	 */
 	public var mouseOver(get, never):Bool;
-	
+
 	private function get_mouseOver():Bool
 	{
 		return FlxMath.pointInCoordinates(	Math.floor( FlxG.mouse.screenX + scrollFactor.x * (FlxG.mouse.x - FlxG.mouse.screenX) ),
@@ -838,50 +838,50 @@ class FlxExtendedSprite extends FlxSprite
 											Math.floor(height)
 											);
 	}
-	
+
 	/**
 	 * Returns how many horizontal pixels the mouse pointer is inside this sprite from the top left corner. Returns -1 if outside.
 	 */
 	public var mouseX(get, never):Int;
-	
+
 	private function get_mouseX():Int
 	{
 		if (mouseOver)
 		{
 			return Math.floor(FlxG.mouse.x - x);
 		}
-		
+
 		return -1;
 	}
-	
+
 	/**
 	 * Returns how many vertical pixels the mouse pointer is inside this sprite from the top left corner. Returns -1 if outside.
 	 */
 	public var mouseY(get, never):Int;
-	
+
 	private function get_mouseY():Int
 	{
 		if (mouseOver)
 		{
 			return Math.floor(FlxG.mouse.y - y);
 		}
-		
+
 		return -1;
 	}
 	#end
-	
+
 	/**
 	 * Returns a <code>FlxRect</code> consisting of the bounds of this Sprite.
 	 */
 	public var rect(get, never):FlxRect;
-	
+
 	private function get_rect():FlxRect
 	{
 		_rect.x = x;
 		_rect.y = y;
 		_rect.width = width;
 		_rect.height = height;
-		
+
 		return _rect;
 	}
 }

--- a/flixel/addons/display/FlxNestedSprite.hx
+++ b/flixel/addons/display/FlxNestedSprite.hx
@@ -1,13 +1,13 @@
 package flixel.addons.display;
 
 import flash.geom.ColorTransform;
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.FlxObject;
-import flixel.FlxSprite;
-import flixel.util.FlxAngle;
-import flixel.util.FlxArrayUtil;
-import flixel.util.FlxMath;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.FlxObject;
+import org.flixel.FlxSprite;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxArrayUtil;
+import org.flixel.util.FlxMath;
 
 /**
  * Some sort of DisplayObjectContainer but very limited.
@@ -24,12 +24,12 @@ class FlxNestedSprite extends FlxSprite
 	 * Y position of this sprite relative to parent, 0 by default
 	 */
 	public var relativeY:Float;
-	
+
 	/**
 	 * Angle of this sprite relative to parent
 	 */
 	public var relativeAngle:Float;
-	
+
 	/**
 	 * X scale of this sprite relative to parent
 	 */
@@ -38,7 +38,7 @@ class FlxNestedSprite extends FlxSprite
 	 * Y scale of this sprite relative to parent
 	 */
 	public var relativeScaleY:Float;
-	
+
 	/**
 	 * X velocity relative to parent sprite
 	 */
@@ -51,7 +51,7 @@ class FlxNestedSprite extends FlxSprite
 	 * Angular velocity relative to parent sprite
 	 */
 	public var relativeAngularVelocity:Float;
-	
+
 	/**
 	 * X acceleration relative to parent sprite
 	 */
@@ -64,54 +64,54 @@ class FlxNestedSprite extends FlxSprite
 	 * Angular acceleration relative to parent sprite
 	 */
 	public var relativeAngularAcceleration:Float;
-	
+
 	public var _parentAlpha:Float = 1;
 	public var _parentRed:Float = 1;
 	public var _parentGreen:Float = 1;
 	public var _parentBlue:Float = 1;
-	
+
 	/**
 	 * List of all nested sprites
 	 */
 	private var _children:Array<FlxNestedSprite>;
-	
-	public function new(X:Float = 0, Y:Float = 0, ?SimpleGraphic:Dynamic) 
+
+	public function new(X:Float = 0, Y:Float = 0, ?SimpleGraphic:Dynamic)
 	{
 		super(X, Y, SimpleGraphic);
-		
+
 		_children = [];
 		relativeX = 0;
 		relativeY = 0;
 		relativeAngle = 0;
 		relativeScaleX = 1;
 		relativeScaleY = 1;
-		
+
 		relativeVelocityX = 0;
 		relativeVelocityY = 0;
 		relativeAngularVelocity = 0;
-		
+
 		relativeAccelerationX = 0;
 		relativeAccelerationY = 0;
 		relativeAngularAcceleration = 0;
 	}
-	
+
 	/**
-	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you 
+	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you
 	 * want to disable it temporarily only and <code>reset()</code> it later to revive it.
 	 * Used to clean up memory.
 	 */
 	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		for (child in _children)
 		{
 			child.destroy();
 		}
-		
+
 		_children = null;
 	}
-	
+
 	/**
 	 * Adds the <code>FlxNestedSprite</code> to the children list.
 	 * @param	Child	The <code>FlxNestedSprite</code> to add.
@@ -126,23 +126,23 @@ class FlxNestedSprite extends FlxSprite
 			Child.acceleration.x = Child.acceleration.y = 0;
 			Child.scrollFactor.x = scrollFactor.x;
 			Child.scrollFactor.y = scrollFactor.y;
-			
+
 			Child._parentAlpha = this.alpha;
 			Child.alpha = Child.alpha;
 
 			var thisRed:Float = (color >> 16) / 255;
 			var thisGreen:Float = (color >> 8 & 0xff) / 255;
 			var thisBlue:Float = (color & 0xff) / 255;
-			
+
 			Child._parentRed = thisRed;
 			Child._parentGreen = thisGreen;
 			Child._parentBlue = thisBlue;
 			Child.color = Child.color;
 		}
-		
+
 		return Child;
 	}
-	
+
 	/**
 	 * Removes the <code>FlxNestedSprite</code> from the children list.
 	 * @param	Child	The <code>FlxNestedSprite</code> to remove.
@@ -151,15 +151,15 @@ class FlxNestedSprite extends FlxSprite
 	public function remove(Child:FlxNestedSprite):FlxNestedSprite
 	{
 		var index:Int = FlxArrayUtil.indexOf(_children, Child);
-		
+
 		if (index >= 0)
 		{
 			_children.splice(index, 1);
 		}
-		
+
 		return Child;
 	}
-	
+
 	/**
 	 * Removes the <code>FlxNestedSprite</code> from the position in the children list.
 	 * @param	Index	Index to remove.
@@ -170,13 +170,13 @@ class FlxNestedSprite extends FlxSprite
 		{
 			return null;
 		}
-		
+
 		var child:FlxNestedSprite = _children[Index];
 		_children.splice(Index, 1);
-		
+
 		return child;
 	}
-	
+
 	/**
 	 * Removes all children sprites from this sprite.
 	 */
@@ -188,95 +188,95 @@ class FlxNestedSprite extends FlxSprite
 			removeAt(--i);
 		}
 	}
-	
+
 	/**
 	 * All Graphics in this list.
 	 */
 	public var children(get, never):Array<FlxNestedSprite>;
-	
-	inline private function get_children():Array<FlxNestedSprite> 
-	{ 
-		return _children; 
+
+	inline private function get_children():Array<FlxNestedSprite>
+	{
+		return _children;
 	}
-	
+
 	/**
 	 * Amount of Graphics in this list.
 	 */
 	public var count(get, never):Int;
-	
-	private function get_count():Int 
-	{ 
-		return _children.length; 
+
+	private function get_count():Int
+	{
+		return _children.length;
 	}
-	
-	public function preUpdate():Void 
+
+	public function preUpdate():Void
 	{
 		#if !FLX_NO_DEBUG
 		FlxBasic._ACTIVECOUNT++;
 		#end
-		
+
 		last.x = x;
 		last.y = y;
-		
+
 		for (child in _children)
 		{
 			child.preUpdate();
 		}
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		preUpdate();
-		
+
 		for (child in _children)
 		{
 			child.update();
 		}
-		
+
 		postUpdate();
 	}
-	
-	public function postUpdate():Void 
+
+	public function postUpdate():Void
 	{
 		if (moves)
 		{
 			updateMotion();
 		}
-		
+
 		wasTouching = touching;
 		touching = FlxObject.NONE;
 		updateAnimation();
-		
-		
+
+
 		var delta:Float;
 		var velocityDelta:Float;
 		var dt:Float = FlxG.elapsed;
-		
+
 		velocityDelta = 0.5 * (FlxMath.computeVelocity(relativeAngularVelocity, relativeAngularAcceleration, angularDrag, maxAngular) - relativeAngularVelocity);
-		relativeAngularVelocity += velocityDelta; 
+		relativeAngularVelocity += velocityDelta;
 		relativeAngle += relativeAngularVelocity * dt;
 		relativeAngularVelocity += velocityDelta;
-		
+
 		velocityDelta = 0.5 * (FlxMath.computeVelocity(relativeVelocityX, relativeAccelerationX, drag.x, maxVelocity.x) - relativeVelocityX);
 		relativeVelocityX += velocityDelta;
 		delta = relativeVelocityX * dt;
 		relativeVelocityX += velocityDelta;
 		relativeX += delta;
-		
+
 		velocityDelta = 0.5 * (FlxMath.computeVelocity(relativeVelocityY, relativeAccelerationY, drag.y, maxVelocity.y) - relativeVelocityY);
 		relativeVelocityY += velocityDelta;
 		delta = relativeVelocityY * dt;
 		relativeVelocityY += velocityDelta;
 		relativeY += delta;
-		
-		
+
+
 		for (child in _children)
 		{
 			child.velocity.x = child.velocity.y = 0;
 			child.acceleration.x = child.acceleration.y = 0;
 			child.angularVelocity = child.angularAcceleration = 0;
 			child.postUpdate();
-			
+
 			if (simpleRenderSprite())
 			{
 				child.x = x + child.relativeX - offset.x;
@@ -287,50 +287,50 @@ class FlxNestedSprite extends FlxSprite
 				var radians:Float = angle * FlxAngle.TO_RAD;
 				var cos:Float = Math.cos(radians);
 				var sin:Float = Math.sin(radians);
-				
+
 				var dx:Float = child.relativeX - offset.x;
 				var dy:Float = child.relativeY - offset.y;
-				
+
 				var relX:Float = (dx * cos * scale.x - dy * sin * scale.y);
 				var relY:Float = (dx * sin * scale.x + dy * cos * scale.y);
-				
+
 				child.x = x + relX;
 				child.y = y + relY;
 			}
-			
+
 			child.angle = angle + child.relativeAngle;
 			child.scale.x = scale.x * child.relativeScaleX;
 			child.scale.y = scale.y * child.relativeScaleY;
-			
+
 			child.velocity.x = velocity.x;
 			child.velocity.y = velocity.y;
 			child.acceleration.x = acceleration.x;
 			child.acceleration.y = acceleration.y;
 		}
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		super.draw();
-		
+
 		for (child in _children)
 		{
 			child.draw();
 		}
 	}
-	
+
 	#if !FLX_NO_DEBUG
-	override public function drawDebug():Void 
+	override public function drawDebug():Void
 	{
 		super.drawDebug();
-		
+
 		for (child in _children)
 		{
 			child.drawDebug();
 		}
 	}
 	#end
-	
+
 	override private function set_alpha(Alpha:Float):Float
 	{
 		if (Alpha > 1)
@@ -353,7 +353,7 @@ class FlxNestedSprite extends FlxSprite
 			var red:Float = (color >> 16) * _parentRed / 255;
 			var green:Float = (color >> 8 & 0xff) * _parentGreen / 255;
 			var blue:Float = (color & 0xff) * _parentBlue / 255;
-			
+
 			if (_colorTransform == null)
 			{
 				_colorTransform = new ColorTransform(red, green, blue, alpha);
@@ -380,7 +380,7 @@ class FlxNestedSprite extends FlxSprite
 		}
 		dirty = true;
 		#end
-		
+
 		if (_children != null)
 		{
 			for (child in _children)
@@ -389,20 +389,20 @@ class FlxNestedSprite extends FlxSprite
 				child._parentAlpha = alpha;
 			}
 		}
-		
+
 		return alpha;
 	}
-	
+
 	override private function set_color(Color:Int):Int
 	{
 		Color &= 0x00ffffff;
-		
+
 		var combinedRed:Float = (Color >> 16) * _parentRed / 255;
 		var combinedGreen:Float = (Color >> 8 & 0xff) * _parentGreen / 255;
 		var combinedBlue:Float = (Color & 0xff) * _parentBlue / 255;
-		
+
 		var combinedColor:Int = Std.int(combinedRed * 255) << 16 | Std.int(combinedGreen * 255) << 8 | Std.int(combinedBlue * 255);
-		
+
 		if (color == combinedColor)
 		{
 			return color;
@@ -434,32 +434,32 @@ class FlxNestedSprite extends FlxSprite
 			}
 			useColorTransform = false;
 		}
-		
+
 		dirty = true;
-		
+
 		#if !flash
 		_red = combinedRed;
 		_green = combinedGreen;
 		_blue = combinedBlue;
 		#end
-		
+
 		for (child in _children)
 		{
 			var childColor:Int = child.color;
-			
+
 			var childRed:Float = (childColor >> 16) / (255 * child._parentRed);
 			var childGreen:Float = (childColor >> 8 & 0xff) / (255 * child._parentGreen);
 			var childBlue:Float = (childColor & 0xff) / (255 * child._parentBlue);
-			
+
 			combinedColor = Std.int(childRed * combinedRed * 255) << 16 | Std.int(childGreen * combinedGreen * 255) << 8 | Std.int(childBlue * combinedBlue * 255);
-			
+
 			child.color = combinedColor;
-			
+
 			child._parentRed = combinedRed;
 			child._parentGreen = combinedGreen;
 			child._parentBlue = combinedBlue;
 		}
-		
+
 		return color;
 	}
 }

--- a/flixel/addons/display/FlxSkewedSprite.hx
+++ b/flixel/addons/display/FlxSkewedSprite.hx
@@ -1,14 +1,14 @@
 package flixel.addons.display;
 
 import flash.geom.Matrix;
-import flixel.FlxBasic;
-import flixel.FlxCamera;
-import flixel.FlxG;
-import flixel.FlxObject;
-import flixel.FlxSprite;
-import flixel.system.layer.DrawStackItem;
-import flixel.util.FlxAngle;
-import flixel.util.FlxPoint;
+import org.flixel.FlxBasic;
+import org.flixel.FlxCamera;
+import org.flixel.FlxG;
+import org.flixel.FlxObject;
+import org.flixel.FlxSprite;
+import org.flixel.system.layer.DrawStackItem;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxPoint;
 
 /**
  * ...
@@ -17,37 +17,37 @@ import flixel.util.FlxPoint;
 class FlxSkewedSprite extends FlxSprite
 {
 	public var skew:IFlxPoint;
-	
+
 	private var _skewMatrix:Matrix;
-	
-	public function new(X:Float = 0, Y:Float = 0) 
+
+	public function new(X:Float = 0, Y:Float = 0)
 	{
 		super(X, Y);
-		
+
 		skew = new FlxPoint();
 		_skewMatrix = new Matrix();
 	}
-	
+
 	/**
-	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you 
+	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you
 	 * want to disable it temporarily only and <code>reset()</code> it later to revive it.
 	 * Used to clean up memory.
 	 */
-	override public function destroy():Void 
+	override public function destroy():Void
 	{
 		skew = null;
 		_skewMatrix = null;
-		
+
 		super.destroy();
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
-		if (dirty)	//rarely 
+		if (dirty)	//rarely
 		{
 			calcFrame();
 		}
-		
+
 		if (cameras == null)
 		{
 			cameras = FlxG.cameras.list;
@@ -55,26 +55,26 @@ class FlxSkewedSprite extends FlxSprite
 		var camera:FlxCamera;
 		var i:Int = 0;
 		var l:Int = cameras.length;
-		
+
 		#if !flash
 		var drawItem:DrawStackItem;
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
 		#end
-		
+
 		var radians:Float;
 		var cos:Float;
 		var sin:Float;
-		
+
 		while(i < l)
 		{
 			camera = cameras[i++];
-			
+
 			if (!onScreen(camera) || !camera.visible || !camera.exists)
 			{
 				continue;
 			}
-			
+
 		#if !flash
 			#if !js
 			drawItem = camera.getDrawStackItem(cachedGraphics, isColored, _blendInt, antialiasing);
@@ -84,13 +84,13 @@ class FlxSkewedSprite extends FlxSprite
 			#end
 			currDrawData = drawItem.drawData;
 			currIndex = drawItem.position;
-			
+
 			_point.x = x - (camera.scroll.x * scrollFactor.x) - (offset.x);
 			_point.y = y - (camera.scroll.y * scrollFactor.y) - (offset.y);
-			
+
 			_point.x = (_point.x) + origin.x;
 			_point.y = (_point.y) + origin.y;
-			
+
 			#if js
 			_point.x = Math.floor(_point.x);
 			_point.y = Math.floor(_point.y);
@@ -99,7 +99,7 @@ class FlxSkewedSprite extends FlxSprite
 			_point.x = x - (camera.scroll.x * scrollFactor.x) - (offset.x);
 			_point.y = y - (camera.scroll.y * scrollFactor.y) - (offset.y);
 		#end
-		
+
 #if flash
 			if (simpleRenderSprite())
 			{
@@ -121,10 +121,10 @@ class FlxSkewedSprite extends FlxSprite
 					_skewMatrix.identity();
 					_skewMatrix.b = Math.tan(skew.y * FlxAngle.TO_RAD);
 					_skewMatrix.c = Math.tan(skew.x * FlxAngle.TO_RAD);
-					
+
 					_matrix.concat(_skewMatrix);
 				}
-				
+
 				_matrix.translate(_point.x + origin.x, _point.y + origin.y);
 				camera.buffer.draw(framePixels, _matrix, null, blend, null, antialiasing);
 			}
@@ -135,9 +135,9 @@ class FlxSkewedSprite extends FlxSprite
 			var csy:Float = 1;
 			var x2:Float = 0;
 			var y2:Float = 0;
-			
+
 			var isFlipped:Bool = (flipped != 0) && (facing == FlxObject.LEFT);
-			
+
 			if (simpleRenderSprite())
 			{
 				if (isFlipped)
@@ -150,23 +150,23 @@ class FlxSkewedSprite extends FlxSprite
 				radians = -angle * FlxAngle.TO_RAD;
 				cos = Math.cos(radians);
 				sin = Math.sin(radians);
-				
+
 				csx = cos * scale.x;
 				ssy = sin * scale.y;
 				ssx = sin * scale.x;
 				csy = cos * scale.y;
-				
+
 				var x1:Float = (origin.x - _halfWidth);
 				var y1:Float = (origin.y - _halfHeight);
 				x2 = x1 * csx + y1 * ssy;
 				y2 = -x1 * ssx + y1 * csy;
-				
+
 				_matrix.identity();
 				_matrix.a = cos;
 				_matrix.b = -sin;
 				_matrix.c = sin;
 				_matrix.d = cos;
-				
+
 				if (isFlipped)
 				{
 					_matrix.scale( -scale.x, scale.y);
@@ -175,32 +175,32 @@ class FlxSkewedSprite extends FlxSprite
 				{
 					_matrix.scale(scale.x, scale.y);
 				}
-				
+
 				if (skew.x != 0 || skew.y != 0)
 				{
 					_skewMatrix.identity();
-					
+
 					_skewMatrix.b = Math.tan(skew.y * FlxAngle.TO_RAD);
 					_skewMatrix.c = Math.tan(skew.x * FlxAngle.TO_RAD);
-					
+
 					_matrix.concat(_skewMatrix);
 				}
-				
+
 				csx = _matrix.a;
 				ssy = _matrix.b;
 				ssx = _matrix.c;
 				csy = _matrix.d;
 			}
-			
+
 			currDrawData[currIndex++] = _point.x - x2;
 			currDrawData[currIndex++] = _point.y - y2;
 			currDrawData[currIndex++] = frame.tileID;
-			
+
 			currDrawData[currIndex++] = csx;
 			currDrawData[currIndex++] = ssy;
 			currDrawData[currIndex++] = ssx;
 			currDrawData[currIndex++] = csy;
-			
+
 			#if !js
 			if (isColored)
 			{
@@ -209,13 +209,13 @@ class FlxSkewedSprite extends FlxSprite
 				currDrawData[currIndex++] = _blue;
 			}
 			currDrawData[currIndex++] = alpha;
-			#else 
+			#else
 			if (useAlpha)
 			{
 				currDrawData[currIndex++] = alpha;
 			}
 			#end
-			
+
 			drawItem.position = currIndex;
 #end
 			#if !FLX_NO_DEBUG
@@ -223,7 +223,7 @@ class FlxSkewedSprite extends FlxSprite
 			#end
 		}
 	}
-	
+
 	private override function simpleRenderSprite():Bool
 	{
 		#if !flash

--- a/flixel/addons/display/FlxSpriteAniRot.hx
+++ b/flixel/addons/display/FlxSpriteAniRot.hx
@@ -4,15 +4,15 @@ package flixel.addons.display;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.FlxSprite;
-import flixel.system.layer.frames.FlxSpriteFrames;
-import flixel.util.FlxColor;
-import flixel.util.loaders.CachedGraphics;
+import org.flixel.FlxSprite;
+import org.flixel.system.layer.frames.FlxSpriteFrames;
+import org.flixel.util.FlxColor;
+import org.flixel.util.loaders.CachedGraphics;
 
 /**
- * Creating animated and rotated sprite from an un-rotated animated image. 
+ * Creating animated and rotated sprite from an un-rotated animated image.
  * THE ANIMATION MUST CONTAIN ONLY ONE ROW OF SPRITE FRAMES.
- * 
+ *
  * @version 1.0 - November 8th 2011
  * @link http://www.gameonaut.com
  * @author Simon Etienne Rozner / Gameonaut.com, ported to Haxe by Sam Batista
@@ -28,12 +28,12 @@ class FlxSpriteAniRot extends FlxSprite
 	{
 		super(X, Y);
 		// Just to get the number of frames
-		loadGraphic(AnimatedGraphic, true); 
-		
+		loadGraphic(AnimatedGraphic, true);
+
 		rotations = 360 / Rotations;
 		cached = [];
 		framesCache = [];
-		
+
 		// Load the graphic, create rotations every 10 degrees
 		for (i in 0...frames)
 		{
@@ -44,37 +44,37 @@ class FlxSpriteAniRot extends FlxSprite
 		}
 		bakedRotation = 0;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		cached = null;
 		framesCache = null;
-		
+
 		super.destroy();
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		super.update();
-		
+
 		var oldIndex:Int = angleIndex;
 		var angleHelper:Int = Math.floor(angle % 360);
-		
+
 		while (angleHelper < 0)
 		{
 			angleHelper += 360;
 		}
-		
+
 		angleIndex = Math.floor(angleHelper / rotations + 0.5);
 		angleIndex = Std.int(angleIndex % frames);
-		
+
 		if (oldIndex != angleIndex)
 		{
 			dirty = true;
 		}
 	}
 
-	override private function calcFrame():Void 
+	override private function calcFrame():Void
 	{
 		cachedGraphics = cached[animation.frameIndex];
 		frame = framesCache[animation.frameIndex].frames[angleIndex];

--- a/flixel/addons/editors/ogmo/FlxOgmoLoader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmoLoader.hx
@@ -3,9 +3,9 @@ package flixel.addons.editors.ogmo;
 import openfl.Assets;
 import haxe.xml.Fast;
 import haxe.xml.Parser;
-import flixel.FlxG;
-import flixel.util.FlxPoint;
-import flixel.tile.FlxTilemap;
+import org.flixel.FlxG;
+import org.flixel.util.FlxPoint;
+import org.flixel.tile.FlxTilemap;
 
 class FlxOgmoLoader
 {
@@ -15,29 +15,29 @@ class FlxOgmoLoader
 	// Helper variables to read level data
 	private var _xml:Xml;
 	private var _fastXml:Fast;
-	
+
 	/**
 	 * Creates a new instance of OgmoLevelLoader and prepares the XML level data to be loaded.
-	 * This object can either be contained or ovewritten. 
-	 * 
+	 * This object can either be contained or ovewritten.
+	 *
 	 * IMPORTANT: -> Tile layers must have the Export Mode set to "CSV".
-	 * 			  -> First tile in spritesheet must be blank or debug. It will never get drawn so don't place them in Ogmo! 
+	 * 			  -> First tile in spritesheet must be blank or debug. It will never get drawn so don't place them in Ogmo!
 	 * 			  	 (This is needed to support many other editors that use index 0 as empty.)
-	 * 
+	 *
 	 * @param	LevelData	A String or Class representing the location of xml level data.
 	 */
 	public function new(LevelData:Dynamic)
 	{
 		// Load xml file
 		var str:String = "";
-		
+
 		// Passed embedded resource?
-		if (Std.is(LevelData, Class)) 
+		if (Std.is(LevelData, Class))
 		{
 			str = Type.createInstance(LevelData, []);
 		}
 		// Passed path to resource?
-		else if (Std.is(LevelData, String))  
+		else if (Std.is(LevelData, String))
 		{
 			str = Assets.getText(LevelData);
 		}
@@ -54,29 +54,29 @@ class FlxOgmoLoader
 	/**
 	* Load a Tilemap. Tile layers must have the Export Mode set to "CSV".
 	* Collision with entities should be handled with the reference returned from this function. Here's a tip:
-	* 
-		// IMPORTANT: Always collide the map with objects, not the other way around. 
+	*
+		// IMPORTANT: Always collide the map with objects, not the other way around.
 		//			  This prevents odd collision errors (collision separation code off by 1 px).
 		<code>FlxG.collide(map, obj, notifyCallback);</code>
-	* 
+	*
 	* @param	TileGraphic		A String or Class representing the location of the image asset for the tilemap.
 	* @param	TileWidth		The width of each individual tile.
 	* @param	TileHeight		The height of each individual tile.
 	* @param	TileLayer		The name of the layer the tilemap data is stored in Ogmo editor, usually "tiles" or "stage".
 	* @return	A <code>FlxTilemap</code>, where you can collide your entities against.
-	*/ 
+	*/
 	public function loadTilemap(TileGraphic:Dynamic, TileWidth:Int = 16, TileHeight:Int = 16, TileLayer:String = "tiles"):FlxTilemap
 	{
 		var tileMap:FlxTilemap = new FlxTilemap();
 		tileMap.loadMap(_fastXml.node.resolve(TileLayer).innerData, TileGraphic, TileWidth, TileHeight);
-		
+
 		return tileMap;
 	}
 
 	/**
-	* Parse every entity in the specified layer and call a function that will spawn game objects based on their name. 
+	* Parse every entity in the specified layer and call a function that will spawn game objects based on their name.
 	* Optional data can be read from the xml object, here's an example that reads the position of an object:
-	* 
+	*
 		<code>public function loadEntity( type:String, data:Xml ):Void
 		{
 			switch (type.toLowerCase())
@@ -88,16 +88,16 @@ class FlxOgmoLoader
 				throw "Unrecognized actor type '" + type + "' detected in level file.";
 			}
 		}</code>
-	* 
+	*
 	* @param	EntityLoadCallback		A function that takes in the following parameters (name:String, data:Xml):Void (returns Void) that spawns entities based on their name.
 	* @param	EntityLayer				The name of the layer the entities are stored in Ogmo editor. Usually "entities" or "actors"
-	*/ 
+	*/
 	public function loadEntities(EntityLoadCallback:String->Xml->Void, EntityLayer:String = "entities"):Void
 	{
 		var actors = _fastXml.node.resolve(EntityLayer);
-		
+
 		// Iterate over actors
-		for (a in actors.elements) 
+		for (a in actors.elements)
 		{
 			EntityLoadCallback(a.name, a.x);
 		}

--- a/flixel/addons/editors/spine/FlxSpine.hx
+++ b/flixel/addons/editors/spine/FlxSpine.hx
@@ -3,13 +3,13 @@ package flixel.addons.editors.spine;
 import openfl.Assets;
 import haxe.ds.ObjectMap;
 
-import flixel.FlxG;
-import flixel.FlxCamera;
-import flixel.FlxSprite;
-import flixel.FlxObject;
-import flixel.util.FlxAngle;
-import flixel.util.loaders.CachedGraphics;
-import flixel.util.loaders.TextureRegion;
+import org.flixel.FlxG;
+import org.flixel.FlxCamera;
+import org.flixel.FlxSprite;
+import org.flixel.FlxObject;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.loaders.CachedGraphics;
+import org.flixel.util.loaders.TextureRegion;
 
 import flixel.addons.editors.spine.texture.FlixelTexture;
 import flixel.addons.editors.spine.texture.FlixelTextureLoader;
@@ -27,7 +27,7 @@ import spinehx.attachments.RegionAttachment;
 
 /**
  * A Sprite that can play animations exported by Spine (http://esotericsoftware.com/)
- * 
+ *
  * @author Big thanks to the work on spinehx by nitrobin (https://github.com/nitrobin/spinehx).
  * HaxeFlixel Port by: Sasha (Beeblerox), Sam Batista (crazysam), Kuris Makku (xraven13)
  */
@@ -37,13 +37,13 @@ class FlxSpine extends FlxSprite
 	public var skeletonData:SkeletonData;
 	public var state:AnimationState;
 	public var stateData:AnimationStateData;
-	
+
 	// TODO: adjust collider's position
 	public var collider:FlxObject;
-	
+
 	public var wrapperAngles:ObjectMap<RegionAttachment, Float>;
 	public var cachedSprites:ObjectMap<RegionAttachment, FlxSprite>;
-	
+
 	/**
 	 * Instantiate a new Spine Sprite.
 	 * @param	skeletonData	Animation data from Spine (.json .skel .png), get it like this: FlxSpineSprite.readSkeletonData( "mySpriteData", "assets/" );
@@ -52,88 +52,88 @@ class FlxSpine extends FlxSprite
 	 * @param	Width			The maximum width of this sprite (avoid very large sprites since they are performance intensive).
 	 * @param	Height			The maximum height of this sprite (avoid very large sprites since they are performance intensive).
 	 */
-	public function new(skeletonData:SkeletonData, X:Float = 0, Y:Float = 0) 
+	public function new(skeletonData:SkeletonData, X:Float = 0, Y:Float = 0)
 	{
 		super(X, Y);
-		
+
 		collider = new FlxObject(X, Y);
-		
+
 		width = 0;
 		height = 0;
-		
+
 		this.skeletonData = skeletonData;
-		
+
 		stateData = new AnimationStateData(skeletonData);
 		state = new AnimationState(stateData);
-		
+
 		skeleton = Skeleton.create(skeletonData);
 		skeleton.setX(0);
 		skeleton.setY(0);
 		skeleton.setFlipY(true);
 		//skeleton.setFlipX(true);
-		
+
 		cachedSprites = new ObjectMap<RegionAttachment, FlxSprite>();
 		wrapperAngles = new ObjectMap<RegionAttachment, Float>();
 	}
-	
+
 	override public function destroy():Void
 	{
 		if (collider != null)
 			collider.destroy();
 		collider = null;
-		
+
 		skeletonData = null;
 		skeleton = null;
 		state = null;
 		stateData = null;
 		wrapperAngles = null;
-		
+
 		if (cachedSprites != null)
 		{
 			for (key in cachedSprites.keys())
 			{
 				var sprite:FlxSprite = cachedSprites.get(key);
 				cachedSprites.remove(key);
-				if (sprite != null)	
+				if (sprite != null)
 					sprite.destroy();
 			}
 		}
 		cachedSprites = null;
-		
+
 		super.destroy();
 	}
-	
+
 	public var flipX(get, set):Bool;
-	
+
 	private function get_flipX():Bool
 	{
 		return skeleton.flipX;
 	}
-	
+
 	private function set_flipX(value:Bool):Bool
 	{
 		if (value != skeleton.flipX)
 			skeleton.setFlipX(value);
-			
+
 		facing = (value == true) ? FlxObject.LEFT : FlxObject.RIGHT;
 		return value;
 	}
-	
+
 	public var flipY(get, set):Bool;
-	
+
 	private function get_flipY():Bool
 	{
 		return skeleton.flipY;
 	}
-	
+
 	private function set_flipY(value:Bool):Bool
 	{
 		if (value != skeleton.flipY)
 			skeleton.setFlipY(value);
-			
+
 		return value;
 	}
-	
+
 	/**
 	 * Get Spine animation data.
 	 * @param	DataName	The name of the animation data files exported from Spine (.atlas .json .png).
@@ -149,16 +149,16 @@ class FlxSpine extends FlxSprite
 		var skeletonData:SkeletonData = json.readSkeletonData(DataName, Assets.getText(DataPath + DataName + ".json"));
 		return skeletonData;
 	}
-	
+
 	override public function update():Void
 	{
 		super.update();
-		
+
 		state.update(FlxG.elapsed * FlxG.timeScale);
 		state.apply(skeleton);
 		skeleton.updateWorldTransform();
 	}
-	
+
 	/**
 	 * Called by game loop, updates then blits or renders current frame of animation to the screen
 	 */
@@ -168,21 +168,21 @@ class FlxSpine extends FlxSprite
 		var flipX:Int = (skeleton.flipX) ? -1 : 1;
 		var flipY:Int = (skeleton.flipY) ? 1 : -1;
 		var flip:Int = flipX * flipY;
-		
+
 		var skeletonX:Float = skeleton.getX();
 		var skeletonY:Float = skeleton.getY();
-		
+
 		var radians:Float = angle * FlxAngle.TO_RAD;
 		var cos:Float = Math.cos(radians);
 		var sin:Float = Math.sin(radians);
-		
+
 		var oox:Float = origin.x + offset.x;
 		var ooy:Float = origin.y + offset.y;
-		
-		for (slot in drawOrder) 
+
+		for (slot in drawOrder)
 		{
 			var attachment:Attachment = slot.attachment;
-			if (Std.is(attachment, RegionAttachment)) 
+			if (Std.is(attachment, RegionAttachment))
 			{
 				var regionAttachment:RegionAttachment = cast attachment;
 				regionAttachment.updateVertices(slot);
@@ -193,16 +193,16 @@ class FlxSpine extends FlxSprite
 				var bone:Bone = slot.getBone();
 				var x:Float = regionAttachment.x - region.offsetX;
 				var y:Float = regionAttachment.y - region.offsetY;
-				
+
 				var dx:Float = skeletonX + bone.worldX + x * bone.m00 + y * bone.m01 - oox;
 				var dy:Float = skeletonY + bone.worldY + x * bone.m10 + y * bone.m11 - ooy;
-				
+
 				var relX:Float = (dx * cos * scale.x - dy * sin * scale.y);
 				var relY:Float = (dx * sin * scale.x + dy * cos * scale.y);
-				
+
 				wrapper.x = this.x + relX - wrapper.frameWidth * 0.5;
 				wrapper.y = this.y + relY - wrapper.frameHeight * 0.5;
-				
+
 				wrapper.angle = (-(bone.worldRotation + regionAttachment.rotation) + wrapperAngle) * flip + angle;
 				wrapper.scale.x = (bone.worldScaleX + regionAttachment.scaleX - 1) * flipX * scale.x;
 				wrapper.scale.y = (bone.worldScaleY + regionAttachment.scaleY - 1) * flipY * scale.y;
@@ -212,18 +212,18 @@ class FlxSpine extends FlxSprite
 			}
 		}
 	}
-	
+
 	override public function drawDebugOnCamera(Camera:FlxCamera = null):Void
 	{
 		super.drawDebugOnCamera(Camera);
-		
+
 		collider.drawDebugOnCamera(Camera);
-		
+
 		var drawOrder:Array<Slot> = skeleton.drawOrder;
-		for (slot in drawOrder) 
+		for (slot in drawOrder)
 		{
 			var attachment:Attachment = slot.attachment;
-			if (Std.is(attachment, RegionAttachment)) 
+			if (Std.is(attachment, RegionAttachment))
 			{
 				var regionAttachment:RegionAttachment = cast attachment;
 				var wrapper:FlxSprite = get(regionAttachment);
@@ -231,39 +231,39 @@ class FlxSpine extends FlxSprite
 			}
 		}
 	}
-	
-	public function get(regionAttachment:RegionAttachment):FlxSprite 
+
+	public function get(regionAttachment:RegionAttachment):FlxSprite
 	{
 		if (cachedSprites.exists(regionAttachment))
 			return cachedSprites.get(regionAttachment);
-		
+
 		var region:AtlasRegion = cast regionAttachment.getRegion();
 		var texture:FlixelTexture = cast region.getTexture();
-		
+
 		var cachedGraphic:CachedGraphics = FlxG.bitmap.add(texture.bd);
 		var atlasRegion:TextureRegion = new TextureRegion(cachedGraphic, region.getRegionX(), region.getRegionY());
-		
-		if (region.rotate) 
+
+		if (region.rotate)
 		{
 			atlasRegion.region.tileWidth = atlasRegion.region.width = region.getRegionHeight();
 			atlasRegion.region.tileHeight = atlasRegion.region.height = region.getRegionWidth();
 		}
-		else 
+		else
 		{
 			atlasRegion.region.tileWidth = atlasRegion.region.width = region.getRegionWidth();
 			atlasRegion.region.tileHeight = atlasRegion.region.height = region.getRegionHeight();
 		}
-		
+
 		var wrapper:FlxSprite = new FlxSprite(0, 0, atlasRegion);
 		wrapper.antialiasing = antialiasing;
 		wrapper.origin.x = regionAttachment.width / 2; // Registration point.
 		wrapper.origin.y = regionAttachment.height / 2;
-		if (region.rotate) 
+		if (region.rotate)
 		{
 			wrapper.angle = 90;
 			wrapper.origin.x -= region.getRegionWidth();
 		}
-		
+
 		cachedSprites.set(regionAttachment, wrapper);
 		wrapperAngles.set(regionAttachment, wrapper.angle);
 		return wrapper;

--- a/flixel/addons/editors/tiled/TiledObject.hx
+++ b/flixel/addons/editors/tiled/TiledObject.hx
@@ -1,7 +1,7 @@
 package flixel.addons.editors.tiled;
 
 import haxe.xml.Fast;
-import flixel.util.FlxPoint;
+import org.flixel.util.FlxPoint;
 
 /**
  * Last modified 10/3/2013 by Samuel Batista
@@ -12,19 +12,19 @@ class TiledObject
 {
 	/**
 	 * Use these to determine whether a sprite should be flipped, for example:
-	 * 
+	 *
 		 * var flipped:Bool = cast (oject.gid & TiledObject.FLIPPED_HORIZONTALLY_FLAG);
 		 * sprite.facing = flipped ? FlxObject.LEFT : FlxObject.RIGHT;
 	 */
 	public static inline var FLIPPED_VERTICALLY_FLAG = 0x40000000;
 	public static inline var FLIPPED_HORIZONTALLY_FLAG = 0x80000000;
-	
+
 	public static inline var RECTANGLE = 0;
 	public static inline var ELLIPSE = 1;
 	public static inline var POLYGON = 2;
 	public static inline var POLYLINE = 3;
 	public static inline var TILE = 4;
-	
+
 	public var x:Int;
 	public var y:Int;
 	public var width:Int;
@@ -32,7 +32,7 @@ class TiledObject
 	public var name:String;
 	public var type:String;
 	public var xmlData:Fast;
-	/** 
+	/**
 	 * In degrees
 	 */
 	public var angle:Float;
@@ -44,9 +44,9 @@ class TiledObject
 	 * Custom properties that users can set on this object
 	 */
 	public var custom:TiledPropertySet;
-	/** 
+	/**
 	 * Shared properties are tileset properties added on object tile
-	 */ 
+	 */
 	public var shared:TiledPropertySet;
 	/**
 	 * Information on the group or "Layer" that contains this object
@@ -68,7 +68,7 @@ class TiledObject
 	 * An array with points if the object is a POLYGON or POLYLINE
 	 */
 	public var points:Array<FlxPoint>;
-	
+
 	public function new(Source:Fast, Parent:TiledObjectGroup)
 	{
 		xmlData = Source;
@@ -82,21 +82,21 @@ class TiledObject
 		angle = (Source.has.rotation) ? Std.parseFloat(Source.att.rotation) : 0;
 		// By default let's it be a rectangle object
 		objectType = RECTANGLE;
-		
+
 		// resolve inheritence
 		shared = null;
 		gid = -1;
-		
+
 		// object with tile association?
-		if (Source.has.gid && Source.att.gid.length != 0) 
+		if (Source.has.gid && Source.att.gid.length != 0)
 		{
 			gid = Std.parseInt(Source.att.gid);
 			var set:TiledTileSet;
-			
+
 			for (set in group.map.tilesets)
 			{
 				shared = set.getPropertiesByGid(gid);
-				
+
 				if (shared != null)
 				{
 					break;
@@ -105,16 +105,16 @@ class TiledObject
 			// If there is a gid it means that it's a tile object
 			objectType = TILE;
 		}
-		
+
 		// load properties
 		var node:Xml;
 		custom = new TiledPropertySet();
-		
+
 		for (node in Source.nodes.properties)
 		{
 			custom.extend(node);
 		}
-		
+
 		// Let's see if it's another object
 		if (Source.hasNode.ellipse) {
 			objectType = ELLIPSE;
@@ -126,10 +126,10 @@ class TiledObject
 			getPoints(Source.node.polyline);
 		}
 	}
-	
+
 	private function getPoints(Node:Fast):Void {
 		points = new Array<FlxPoint>();
-		
+
 		var pointsStr:Array<String> = Node.att.points.split(" ");
 		var pair:Array<String>;
 		for (p in pointsStr) {
@@ -137,7 +137,7 @@ class TiledObject
 			points.push(new FlxPoint(Std.parseFloat(pair[0]), Std.parseFloat(pair[1])));
 		}
 	}
-	
+
 	/**
 	 * Property accessors
 	 */

--- a/flixel/addons/nape/FlxNapeSprite.hx
+++ b/flixel/addons/nape/FlxNapeSprite.hx
@@ -1,7 +1,7 @@
 package flixel.addons.nape;
 
-import flixel.FlxSprite;
-import flixel.util.FlxAngle;
+import org.flixel.FlxSprite;
+import org.flixel.util.FlxAngle;
 import nape.geom.Vec2;
 import nape.phys.Body;
 import nape.phys.BodyType;
@@ -13,20 +13,20 @@ import nape.space.Space;
 /**
  * FlxNapeSprite consists of an FlxSprite with a physics body.
  * During the simulation, the sprite follows the physics body position and rotation.
- * 
+ *
  * By default, a rectangular physics body is created upon construction in <code>createRectangularBody()</code>.
- * 
+ *
  * @author TiagoLr ( ~~~ProG4mr~~~ )
  */
 class FlxNapeSprite extends FlxSprite
 {
 	/**
-	 * <code>body</code> is the physics body associated with this sprite. 
+	 * <code>body</code> is the physics body associated with this sprite.
 	 */
 	public var body:Body;
-	
+
 	/**
-	 * Internal var to update <code>body.velocity.x</code> and <code>body.velocity.y</code>. 
+	 * Internal var to update <code>body.velocity.x</code> and <code>body.velocity.y</code>.
 	 * Default is 1, which menas no drag.
 	 */
 	private var _linearDrag:Float = 1;
@@ -38,21 +38,21 @@ class FlxNapeSprite extends FlxSprite
 
 	/**
 	 * Creates an FlxNapeSprite with an optional physics body (<code>body</code>).
-	 * At each step, the physics are updated, and so is the position and rotation of the sprite 
+	 * At each step, the physics are updated, and so is the position and rotation of the sprite
 	 * to match the bodys position and rotation values.
 	 * By default a physics body with rectangle shape will be created around your sprite graphics.
 	 * You can override this functionality and add a premade body of your own (see <code>addPremadeBody</code>).
-	 * 
+	 *
 	 * @param	X						The initial X position of the sprite.
 	 * @param	Y						The initial Y position of the sprite.
 	 * @param	SimpleGraphic 			The graphic you want to display (OPTIONAL - for simple stuff only, do NOT use for animated images!).
 	 * @param	CreateRectangularBody	Whether to create a rectangular body for this sprite (use <code>false</code> if you want to add a custom body).
 	 * @param	EnablePhysics			Whether to enable physics simulation on the rectangular body (only relevant if <code>CreateRectangularBody == true</code>).
 	 */
-	public function new(X:Float = 0, Y:Float = 0, SimpleGraphic:Dynamic = null, CreateRectangularBody:Bool = true, EnablePhysics:Bool = true) 
+	public function new(X:Float = 0, Y:Float = 0, SimpleGraphic:Dynamic = null, CreateRectangularBody:Bool = true, EnablePhysics:Bool = true)
 	{
 		super(X, Y, SimpleGraphic);
-		
+
 		if (CreateRectangularBody)
 		{
 			createRectangularBody();
@@ -61,16 +61,16 @@ class FlxNapeSprite extends FlxSprite
 	}
 
 	/**
-	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you 
+	 * WARNING: This will remove this sprite entirely. Use <code>kill()</code> if you
 	 * want to disable it temporarily only and <code>reset()</code> it later to revive it.
 	 * Override this function to null out variables or manually call
 	 * <code>destroy()</code> on class members if necessary.
 	 * Don't forget to call <code>super.destroy()</code>!
 	 */
-	override public function destroy():Void 
+	override public function destroy():Void
 	{
 		destroyPhysObjects();
-		
+
 		super.destroy();
 	}
 
@@ -80,7 +80,7 @@ class FlxNapeSprite extends FlxSprite
 	override public function update():Void
 	{
 		super.update();
-		
+
 		if (moves)
 		{
 			updatePhysObjects();
@@ -94,7 +94,7 @@ class FlxNapeSprite extends FlxSprite
 	override public function kill():Void
 	{
 		super.kill();
-		
+
 		if (body != null)
 		{
 			body.space = null;
@@ -108,66 +108,66 @@ class FlxNapeSprite extends FlxSprite
 	override public function revive():Void
 	{
 		super.revive();
-		
+
 		if (body != null)
 		{
 			body.space = FlxNapeState.space;
 		}
 	}
-	
+
 	/**
 	 * Makes it easier to add a physics body of your own to this sprite by setting it's position,
 	 * space and material for you.
-	 * 
+	 *
 	 * @param	NewBody 	The new physics body replacing the old one.
 	 */
 	public function addPremadeBody(NewBody:Body):Void
 	{
 		var currSpace:Space = null;
-		
-		if (body != null) 
+
+		if (body != null)
 		{
 			currSpace = body.space;
 			destroyPhysObjects();
 		}
-		
+
 		NewBody.position.x = x;
 		NewBody.position.y = y;
 		NewBody.space = currSpace;
 		body = NewBody;
 		setBodyMaterial();
 	}
-	
+
 	/**
 	 * Creates a circular physics body for this sprite.
-	 * 
+	 *
 	 * @param	Radius	The radius of the circle-shaped body - 16 by default
 	 * @param 	_Type	The <code>BodyType</code> of the physics body. Optional, <code>DYNAMIC</code> by default.
 	 */
 	public function createCircularBody(Radius:Float = 16, ?_Type:BodyType):Void
 	{
 		var currSpace:Space = null;
-		
-		if (body != null) 
+
+		if (body != null)
 		{
 			currSpace = body.space;
 			destroyPhysObjects();
 		}
-			
+
 		centerOffsets(false);
 		body = new Body(_Type != null ? _Type : BodyType.DYNAMIC, Vec2.weak(x, y));
 		body.shapes.add(new Circle(Radius));
 		body.space = currSpace;
-		
+
 		setBodyMaterial();
 	}
-	
+
 	/**
 	 * Default method to create the physics body used by this sprite in shape of a rectangle.
 	 * Override this method to create your own physics body!
 	 * The width and height used are based on the size of sprite graphics if 0 is passed.
 	 * Call this method after calling makeGraphics() or loadGraphic() to update the body size.
-	 * 
+	 *
 	 * @param	Width	The width of the rectangle. 0 = <code>frameWidth</code>
 	 * @param	Height	The height of the rectangle. 0 = <code>frameHeight</code>
 	 * @param	_Type	The <code>BodyType</code> of the physics body. Optional, <code>DYNAMIC</code> by default.
@@ -175,13 +175,13 @@ class FlxNapeSprite extends FlxSprite
 	public function createRectangularBody(Width:Float = 0, Height:Float = 0, ?_Type:BodyType):Void
 	{
 		var currSpace:Space = null;
-		
-		if (body != null) 
+
+		if (body != null)
 		{
 			currSpace = body.space;
 			destroyPhysObjects();
 		}
-		
+
 		if (Width == 0)
 		{
 			Width = frameWidth;
@@ -190,19 +190,19 @@ class FlxNapeSprite extends FlxSprite
 		{
 			Height = frameHeight;
 		}
-		
+
 		centerOffsets(false);
 		body = new Body(_Type != null ? _Type : BodyType.DYNAMIC, Vec2.weak(x, y));
 		body.shapes.add(new Polygon(Polygon.box(Width, Height)));
 		body.space = currSpace;
-		
+
 		setBodyMaterial();
 	}
-	
+
 	/**
 	 * Shortcut method to set/change the physics body material.
-	 * 
-	 * @param	Elasticity			Elasticity of material.		
+	 *
+	 * @param	Elasticity			Elasticity of material.
 	 * @param	DynamicFriction		Coeffecient of dynamic friction for material.
 	 * @param	StaticFriction		Coeffecient of static friction for material.
 	 * @param	Density				Density of this Material.
@@ -210,54 +210,54 @@ class FlxNapeSprite extends FlxSprite
 	 */
 	public function setBodyMaterial(Elasticity:Float = 1, DynamicFriction:Float = 0.2, StaticFriction:Float = 0.4, Density:Float = 1, RotationFriction:Float = 0.001):Void
 	{
-		if (body == null) 
+		if (body == null)
 		{
 			return;
 		}
-		
+
 		body.setShapeMaterials(new Material(Elasticity, DynamicFriction, StaticFriction, Density, RotationFriction));
 	}
-	
+
 	/**
 	 * Destroys the physics main body.
 	 */
 	public function destroyPhysObjects():Void
 	{
-		if (body != null) 
+		if (body != null)
 		{
 			FlxNapeState.space.bodies.remove(body);
 			body = null;
 		}
 	}
-	
+
 	/**
 	 * Updates physics FlxSprite graphics to follow this sprite physics object, called at the end of <code>update()</code>.
 	 * Things that are updated: Position, angle, angular and linear drag.
-	 */	
-	private function updatePhysObjects():Void 
+	 */
+	private function updatePhysObjects():Void
 	{
 		x = body.position.x - origin.x;
 		y = body.position.y - origin.y;
-		
+
 		if (body.allowRotation)
 		{
 			angle = body.rotation * FlxAngle.TO_DEG;
 		}
-		
+
 		// Applies custom physics drag.
-		if (_linearDrag < 1 || _angularDrag < 1) 
+		if (_linearDrag < 1 || _angularDrag < 1)
 		{
 			body.angularVel *= _angularDrag;
 			body.velocity.x *= _linearDrag;
 			body.velocity.y *= _linearDrag;
 		}
 	}
-	
+
 	/**
 	 * Enables/Disables this sprites physics body in simulations.
 	 */
 	public var physicsEnabled(default, set):Bool = true;
-	
+
 	inline private function set_physicsEnabled(Value:Bool):Bool
 	{
 		body.space = Value ? FlxNapeState.space : null;
@@ -266,22 +266,22 @@ class FlxNapeSprite extends FlxSprite
 
 	/**
 	 * Nape requires fluid spaces to add empty space linear drag and angular drag.
-	 * This provides a simple drag alternative. 
+	 * This provides a simple drag alternative.
 	 * Set any values to linearDrag or angularDrag to activate this feature for this object.
-	 * 
+	 *
 	 * @param	LinearDrag		Typical value 0.96 (1 = no drag).
 	 * @param	AngularDrag		Typical value 0.96 (1 = no drag);
 	 */
-	inline public function setDrag(LinearDrag:Float = 1, AngularDrag:Float = 1):Void 
+	inline public function setDrag(LinearDrag:Float = 1, AngularDrag:Float = 1):Void
 	{
 		_linearDrag	= LinearDrag;
 		_angularDrag = AngularDrag;
 	}
-	
+
 	#if !FLX_NO_DEBUG
 	/**
 	 * Hide debug outline on physics sprites if the physics debug shapes are turned on
-	 */	
+	 */
 	override public function drawDebug():Void
 	{
 		if (FlxNapeState.debug == null)

--- a/flixel/addons/nape/FlxNapeVelocity.hx
+++ b/flixel/addons/nape/FlxNapeVelocity.hx
@@ -1,9 +1,9 @@
 package flixel.addons.nape;
 
-import flixel.FlxSprite;
-import flixel.system.input.touch.FlxTouch;
-import flixel.util.FlxAngle;
-import flixel.util.FlxPoint;
+import org.flixel.FlxSprite;
+import org.flixel.system.input.touch.FlxTouch;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxPoint;
 import nape.geom.Vec2;
 
 /**
@@ -24,7 +24,7 @@ class FlxNapeVelocity
 		var direction = FlxAngle.angleBetween(Source, Dest);
 		Source.body.applyImpulse(Vec2.fromPolar(Speed, direction));
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	/**
 	 * Move the given FlxNapeSprite towards the mouse pointer coordinates at a steady velocity
@@ -39,7 +39,7 @@ class FlxNapeVelocity
 		Source.body.applyImpulse(Vec2.fromPolar(Speed, direction));
 	}
 	#end
-	
+
 	#if !FLX_NO_TOUCH
 	/**
 	 * Move the given FlxNapeSprite towards a FlxTouch point at a steady velocity
@@ -54,7 +54,7 @@ class FlxNapeVelocity
 		Source.body.applyImpulse(Vec2.fromPolar(Speed, direction));
 	}
 	#end
-	
+
 	/**
 	 * Sets the x/y velocity on the source FlxNapeSprite so it will move towards the target coordinates at the speed given (in pixels per second)
 	 * Timings are approximate due to the way Flash timers work, and irrespective of SWF frame rate. Allow for a variance of +- 50ms.
@@ -68,14 +68,14 @@ class FlxNapeVelocity
 		var direction = FlxAngle.angleBetweenPoint(Source, Target);
 		Source.body.applyImpulse(Vec2.fromPolar(Speed, direction));
 	}
-	
+
 	/**
 	 * Stops a FlxNapeSprite from moving by setting its velocity to 0, 0.
 	 * @param	Source		The FlxNapeSprite to stop
 	 */
 	inline static public function stopVelocity(Source:FlxNapeSprite):Void
 	{
-		Source.body.velocity.set(Vec2.get(0, 0)); 
-		Source.body.velocity.set(Vec2.get(0, 0)); 
+		Source.body.velocity.set(Vec2.get(0, 0));
+		Source.body.velocity.set(Vec2.get(0, 0));
 	}
 }

--- a/flixel/addons/plugin/FlxMouseControl.hx
+++ b/flixel/addons/plugin/FlxMouseControl.hx
@@ -2,16 +2,16 @@ package flixel.addons.plugin;
 
 #if !FLX_NO_MOUSE
 import flixel.addons.display.FlxExtendedSprite;
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.plugin.FlxPlugin;
-import flixel.util.FlxMath;
-import flixel.util.FlxPoint;
-import flixel.util.FlxRect;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.plugin.FlxPlugin;
+import org.flixel.util.FlxMath;
+import org.flixel.util.FlxPoint;
+import org.flixel.util.FlxRect;
 
 /**
  * FlxMouseControl
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
 */
@@ -63,20 +63,20 @@ class FlxMouseControl extends FlxPlugin
 	 * Note that this takes priority over the mouseZone above. If the mouseZone and deadzone are set, the deadzone is used.
 	 */
 	static public var linkToDeadZone:Bool = false;
-	
+
 	/**
 	 * The FlxExtendedSprite that currently has the mouse button pressed on it
 	 */
 	static private var _clickStack:Array<FlxExtendedSprite> = new Array<FlxExtendedSprite>();
 	static private var _clickCoords:FlxPoint;
 	static private var _hasClickTarget:Bool = false;
-	
+
 	static private var _oldX:Int = 0;
 	static private var _oldY:Int = 0;
-	
+
 	/**
 	 * Adds the given FlxExtendedSprite to the stack of potential sprites that were clicked, the stack is then sorted and the final sprite is selected from that
-	 * 
+	 *
 	 * @param	Item	The FlxExtendedSprite that was clicked by the mouse
 	 */
 	static public function addToStack(Item:FlxExtendedSprite):Void
@@ -93,7 +93,7 @@ class FlxMouseControl extends FlxPlugin
 			_clickStack.push(Item);
 		}
 	}
-	
+
 	/**
 	 * Main Update Loop - checks mouse status and updates FlxExtendedSprites accordingly
 	 */
@@ -102,10 +102,10 @@ class FlxMouseControl extends FlxPlugin
 		// Update mouse speed
 		speedX = FlxG.mouse.screenX - _oldX;
 		speedY = FlxG.mouse.screenY - _oldY;
-		
+
 		_oldX = FlxG.mouse.screenX;
 		_oldY = FlxG.mouse.screenY;
-		
+
 		// Is the mouse currently pressed down on a target?
 		if (_hasClickTarget)
 		{
@@ -116,9 +116,9 @@ class FlxMouseControl extends FlxPlugin
 				{
 					// Drag on
 					isDragging = true;
-					
+
 					dragTarget = clickTarget;
-					
+
 					dragTarget.startDrag();
 				}
 			}
@@ -126,7 +126,7 @@ class FlxMouseControl extends FlxPlugin
 			{
 				releaseMouse();
 			}
-			
+
 			if (linkToDeadZone == true)
 			{
 				if (FlxMath.mouseInFlxRect(false, FlxG.camera.deadzone) == false)
@@ -150,7 +150,7 @@ class FlxMouseControl extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Internal function used to release the click / drag targets and reset the mouse state
 	 */
@@ -158,14 +158,14 @@ class FlxMouseControl extends FlxPlugin
 	{
 		//	Mouse is no longer down, so tell the click target it's free - this will also stop dragging if happening
 		clickTarget.mouseReleasedHandler();
-		
+
 		_hasClickTarget = false;
 		clickTarget = null;
-		
+
 		isDragging = false;
 		dragTarget = null;
 	}
-	
+
 	/**
 	 * Once the clickStack is created this sorts it and then picks the sprite with the highest priority (based on sortIndex and sortOrder)
 	 */
@@ -176,31 +176,31 @@ class FlxMouseControl extends FlxPlugin
 		{
 			_clickStack.sort(sortHandler);
 		}
-		
+
 		clickTarget = _clickStack.pop();
-		
+
 		_clickCoords = clickTarget.point;
-		
+
 		_hasClickTarget = true;
-		
+
 		clickTarget.mousePressedHandler();
-		
+
 		_clickStack = [];
 	}
-	
+
 	/**
 	 * Helper function for the sort process.
-	 * 
+	 *
 	 * @param 	Item1	The first object being sorted.
 	 * @param	Item2	The second object being sorted.
-	 * 
+	 *
 	 * @return	An integer value: -1 (item1 before item2), 0 (same), or 1 (item1 after item2)
 	 */
 	private function sortHandler(Item1:FlxExtendedSprite, Item2:FlxExtendedSprite):Int
 	{
 		var prop1 = Reflect.getProperty(Item1, sortIndex);
 		var prop2 = Reflect.getProperty(Item2, sortIndex);
-		
+
 		if (prop1 < prop2)
 		{
 			return sortOrder;
@@ -209,38 +209,38 @@ class FlxMouseControl extends FlxPlugin
 		{
 			return - sortOrder;
 		}
-		
+
 		return 0;
 	}
-	
+
 	/**
 	 * Removes all references to any click / drag targets and resets this class
 	 */
 	public static function clear():Void
 	{
 		_hasClickTarget = false;
-		
+
 		if (clickTarget != null)
 		{
 			clickTarget.mouseReleasedHandler();
 		}
-		
+
 		clickTarget = null;
-		
+
 		isDragging = false;
-		
+
 		if (dragTarget != null)
 		{
 			dragTarget.stopDrag();
 		}
-		
+
 		speedX = 0;
 		speedY = 0;
 		dragTarget = null;
 		mouseZone = null;
 		linkToDeadZone = false;
 	}
-	
+
 	/**
 	 * Runs when this plugin is destroyed
 	 */

--- a/flixel/addons/plugin/FlxScrollingText.hx
+++ b/flixel/addons/plugin/FlxScrollingText.hx
@@ -1,9 +1,9 @@
 /**
  * FlxScrollingText
  * -- Part of the Flixel Power Tools set
- * 
+ *
  * v1.0 First version released
- * 
+ *
  * @version 1.0 - May 5th 2011
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
@@ -14,8 +14,8 @@ package plugins;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.*;
-import flixel.plugin.FlxPlugin;
+import org.flixel.*;
+import org.flixel.plugin.FlxPlugin;
 import flixel.addons.text.FlxBitmapFont;
 
 class FlxScrollingText extends FlxPlugin
@@ -27,7 +27,7 @@ class FlxScrollingText extends FlxPlugin
      * Adds an FlxBitmapFont to the Scrolling Text Manager and returns an FlxSprite which contains the text scroller in it.<br />
      * The FlxSprite will automatically update itself via this plugin, but can be treated as a normal FlxSprite in all other regards<br />
      * re: positioning, collision, rotation, etc.
-     * 
+     *
      * @param	bitmapFont			A pre-prepared FlxBitmapFont object (see the Test Suite examples for details on how this works)
      * @param	region				A Rectangle that defines the size of the scrolling FlxSprite. The sprite will be placed at region.x/y and be region.width/height in size.
      * @param	pixels				The number of pixels to scroll per step. For a smooth (but slow) scroll use low values. Keep the value proportional to the font width, so if the font width is 16 use a value like 1, 2, 4 or 8.
@@ -35,29 +35,29 @@ class FlxScrollingText extends FlxPlugin
      * @param	text				The default text for your scrolling message. Can be changed in real-time via the addText method.
      * @param	onlyScrollOnscreen	Only update the text scroller when this FlxSprite is visible on-screen? Default true.
      * @param	loopOnWrap			When the scroller reaches the end of the given "text" should it wrap to the start? Default true. If false it will clear the screen then set itself to not update.
-     * 
+     *
      * @return	An FlxSprite of size region.width/height, positioned at region.x/y, that auto-updates its contents while this plugin runs
      */
     public static function add(bitmapFont:FlxBitmapFont, region:Rectangle, pixels:UInt = 1, steps:UInt = 0, text:String = "FLIXEL ROCKS!", onlyScrollOnscreen:Bool = true, loopOnWrap:Bool = true):FlxSprite
     {
         var data:Dynamic = {};
-        
+
         //	Sanity checks
         if (pixels > bitmapFont.characterWidth)
         {
             pixels = bitmapFont.characterWidth;
         }
-        
+
         if (pixels == 0)
         {
             pixels = 1;
         }
-        
+
         if (text == "")
         {
             text = " ";
         }
-        
+
         data.bitmapFont = cast(bitmapFont, FlxBitmapFont);
         data.bitmapChar = data.bitmapFont.getCharacterAsBitmapData(text.charAt(0));
         data.charWidth = bitmapFont.characterWidth;
@@ -67,37 +67,37 @@ class FlxScrollingText extends FlxPlugin
         data.slice = new Rectangle(0, 0, pixels, data.charHeight);
         data.endPoint = new Point(region.width - pixels, 0);
         data.x = 0;
-        
+
         data.sprite = new FlxSprite(Std.int(region.x), Std.int(region.y)).makeGraphic(Std.int(region.width), Std.int(region.height), 0x0, true);
         data.buffer = new BitmapData(Std.int(region.width), Std.int(region.height), true, 0x0);
-        
+
         data.region = region;
         data.step = steps;
         data.maxStep = steps;
         data.pixels = pixels;
         data.clearCount = 0;
         data.clearDistance = region.width - pixels;
-        
+
         data.text = text;
         data.currentChar = 0;
         data.maxChar = text.length;
-        
+
         data.wrap = loopOnWrap;
         data.complete = false;
         data.scrolling = true;
         data.onScreenScroller = onlyScrollOnscreen;
-        
+
         scroll(data);
-        
+
         members.set(data.sprite, data);
-        
+
         return data.sprite;
     }
-    
+
     /**
      * Adds or replaces the text in the given Text Scroller.<br />
      * Can be called while the scroller is still active.
-     * 
+     *
      * @param	source		The FlxSprite Text Scroller you wish to update (must have been added to FlxScrollingText via a call to add()
      * @param	text		The text to add or update to the Scroller
      * @param	overwrite	If true the given text will fully replace the previous scroller text. If false it will be appended to the end (default)
@@ -112,10 +112,10 @@ class FlxScrollingText extends FlxPlugin
         {
             members.get(source).text = members.get(source).text.concat(text);
         }
-            
+
         members.get(source).maxChar = members.get(source).text.length;
     }
-    
+
     override public function draw():Void
     {
         for (obj in members)
@@ -126,15 +126,15 @@ class FlxScrollingText extends FlxPlugin
             }
         }
     }
-    
+
     private static function scroll(data:Dynamic):Void
     {
         //	Have we reached enough steps?
-        
+
         if (data.maxStep > 0 && (data.step < data.maxStep))
         {
             data.step++;
-            
+
             return;
         }
         else
@@ -142,26 +142,26 @@ class FlxScrollingText extends FlxPlugin
             //	It's time to render, so reset the step counter and lets go
             data.step = 0;
         }
-        
+
         //	CLS
         data.buffer.fillRect(data.bufferRect, 0x0);
-        
+
         //	Shift the current contents of the buffer along by "speed" pixels
         data.buffer.copyPixels(cast(data.sprite, FlxSprite).pixels, data.shiftRect, zeroPoint, null, null, true);
-        
+
         //	Copy the side of the character
         if (data.complete == false)
         {
             data.buffer.copyPixels(data.bitmapChar, data.slice, data.endPoint, null, null, true);
-            
+
             //	Update
             data.x += data.pixels;
-            
+
             if (data.x >= data.charWidth)
             {
                 //	Get the next character
                 data.currentChar++;
-                
+
                 if (data.currentChar > data.maxChar)
                 {
                     //	At the end of the text
@@ -175,14 +175,14 @@ class FlxScrollingText extends FlxPlugin
                         data.clearCount = 0;
                     }
                 }
-                
+
                 if (data.complete == false)
                 {
                     data.bitmapChar = data.bitmapFont.getCharacterAsBitmapData(data.text.charAt(data.currentChar));
                     data.x = 0;
                 }
             }
-            
+
             if (data.complete == false)
             {
                 data.slice.x = data.x;
@@ -191,7 +191,7 @@ class FlxScrollingText extends FlxPlugin
         else
         {
             data.clearCount += data.pixels;
-            
+
             //	It's all over now
             if (data.clearCount >= data.clearDistance)
             {
@@ -199,11 +199,11 @@ class FlxScrollingText extends FlxPlugin
                 data.scrolling = false;
             }
         }
-        
+
         cast(data.sprite, FlxSprite).pixels = data.buffer.clone();
         data.sprite.dirty = true;
     }
-    
+
     /**
      * Removes all FlxSprites<br />
      * This is called automatically if the plugin is destroyed, but should be called manually by you if you change States<br />
@@ -216,11 +216,11 @@ class FlxScrollingText extends FlxPlugin
             members.remove(obj.sprite);
         }
     }
-    
+
     /**
      * Starts scrolling on the given FlxSprite. If no FlxSprite is given it starts scrolling on all FlxSprites currently added.<br />
      * Scrolling is enabled by default, but this can be used to re-start it if you have stopped it via stopScrolling.<br />
-     * 
+     *
      * @param	source	The FlxSprite to start scrolling on. If left as null it will start scrolling on all sprites.
      */
     public static function startScrolling(source:FlxSprite = null):Void
@@ -237,11 +237,11 @@ class FlxScrollingText extends FlxPlugin
             }
         }
     }
-    
+
     /**
      * Stops scrolling on the given FlxSprite. If no FlxSprite is given it stops scrolling on all FlxSprites currently added.<br />
      * Scrolling is enabled by default, but this can be used to stop it.<br />
-     * 
+     *
      * @param	source	The FlxSprite to stop scrolling on. If left as null it will stop scrolling on all sprites.
      */
     public static function stopScrolling(source:FlxSprite = null):Void
@@ -258,11 +258,11 @@ class FlxScrollingText extends FlxPlugin
             }
         }
     }
-    
+
     /**
      * Checks to see if the given FlxSprite is a Scrolling Text, and is actively scrolling or not<br />
      * Note: If the text is set to only scroll when on-screen, but if off-screen when this is called, it will still return true.
-     * 
+     *
      * @param	source	The FlxSprite to check for scrolling on.
      * @return	Bool true is the FlxSprite was found and is scrolling, otherwise false
      */
@@ -272,13 +272,13 @@ class FlxScrollingText extends FlxPlugin
         {
             return members.get(source).scrolling;
         }
-        
+
         return false;
     }
-    
+
     /**
      * Removes an FlxSprite from the Text Scroller. Note that it doesn't restore the sprite bitmapData.
-     * 
+     *
      * @param	source	The FlxSprite to remove scrolling for.
      * @return	Bool	true if the FlxSprite was removed, otherwise false.
      */
@@ -287,16 +287,16 @@ class FlxScrollingText extends FlxPlugin
         if (members.exists(source))
         {
             members.remove(source);
-            
+
             return true;
         }
-        
+
         return false;
     }
-    
+
     override public function destroy():Void
     {
         clear();
     }
-    
+
 }

--- a/flixel/addons/plugin/control/FlxControl.hx
+++ b/flixel/addons/plugin/control/FlxControl.hx
@@ -1,9 +1,9 @@
 package flixel.addons.plugin.control;
 
 #if !FLX_NO_KEYBOARD
-import flixel.FlxBasic;
-import flixel.FlxSprite;
-import flixel.plugin.FlxPlugin;
+import org.flixel.FlxBasic;
+import org.flixel.FlxSprite;
+import org.flixel.plugin.FlxPlugin;
 import haxe.ds.ObjectMap;
 
 /**
@@ -19,15 +19,15 @@ class FlxControl extends FlxPlugin
 	static public var player2:FlxControlHandler;
 	static public var player3:FlxControlHandler;
 	static public var player4:FlxControlHandler;
-	
+
 	//	Additional control handlers
 	static private var _members:ObjectMap<FlxControlHandler, FlxControlHandler> = new ObjectMap<FlxControlHandler, FlxControlHandler>();
-	
+
 	/**
 	 * Creates a new FlxControlHandler. You can have as many FlxControlHandlers as you like, but you usually only have one per player. The first handler you make
 	 * will be assigned to the FlxControl.player1 var. The 2nd to FlxControl.player2 and so on for player3 and player4. Beyond this you need to keep a reference to the
 	 * handler yourself.
-	 * 
+	 *
 	 * @param	Sprite			The FlxSprite you want this class to control. It can only control one FlxSprite at once.
 	 * @param	MovementType	Set to either MOVEMENT_INSTANT or MOVEMENT_ACCELERATES
 	 * @param	StoppingType	Set to STOPPING_INSTANT, STOPPING_DECELERATES or STOPPING_NEVER
@@ -38,7 +38,7 @@ class FlxControl extends FlxPlugin
 	static public function create(Sprite:FlxSprite, MovementType:Int, StoppingType:Int, Player:Int = 1, UpdateFacing:Bool = false, EnableArrowKeys:Bool = true):FlxControlHandler
 	{
 		var result:FlxControlHandler;
-		
+
 		if (Player == 1)
 		{
 			player1 = new FlxControlHandler(Sprite, MovementType, StoppingType, UpdateFacing, EnableArrowKeys);
@@ -69,13 +69,13 @@ class FlxControl extends FlxPlugin
 			_members.set(newControlHandler, newControlHandler);
 			result = newControlHandler;
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
-	 * Removes a <code>FlxControlHandler</code> 
-	 * 
+	 * Removes a <code>FlxControlHandler</code>
+	 *
 	 * @param	ControlHandler	The <code>FlxControlHandler</code> to delete
 	 * @return	Boolean	true if the <code>FlxControlHandler</code> was removed, otherwise false.
 	 */
@@ -86,10 +86,10 @@ class FlxControl extends FlxPlugin
 			_members.remove(ControlHandler);
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Removes all FlxControlHandlers.
 	 * This is called automatically if this plugin is ever destroyed.
@@ -101,11 +101,11 @@ class FlxControl extends FlxPlugin
 			_members.remove(handler);
 		}
 	}
-	
+
 	/**
 	 * Starts updating the given FlxControlHandler, enabling keyboard actions for it. If no FlxControlHandler is given it starts updating all FlxControlHandlers currently added.
 	 * Updating is enabled by default, but this can be used to re-start it if you have stopped it via <code>stop()</code>.
-	 * 
+	 *
 	 * @param	ControlHandler	The <code>FlxControlHandler</code> to start updating on. If left as null it will start updating all handlers.
 	 */
 	static public function start(?ControlHandler:FlxControlHandler):Void
@@ -122,11 +122,11 @@ class FlxControl extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Stops updating the given FlxControlHandler. If no FlxControlHandler is given it stops updating all FlxControlHandlers currently added.
 	 * Updating is enabled by default, but this can be used to stop it, for example if you paused your game (see start() to restart it again).
-	 * 
+	 *
 	 * @param	ControlHandler	The FlxControlHandler to stop updating. If left as null it will stop updating all handlers.
 	 */
 	static public function stop(?ControlHandler:FlxControlHandler):Void
@@ -143,7 +143,7 @@ class FlxControl extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Runs update on all currently active FlxControlHandlers
 	 */
@@ -157,7 +157,7 @@ class FlxControl extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Runs when this plugin is destroyed
 	 */

--- a/flixel/addons/plugin/control/FlxControlHandler.hx
+++ b/flixel/addons/plugin/control/FlxControlHandler.hx
@@ -2,27 +2,27 @@ package flixel.addons.plugin.control;
 
 #if !FLX_NO_KEYBOARD
 import flash.geom.Rectangle;
-import flixel.FlxG;
-import flixel.FlxObject;
-import flixel.util.FlxAngle;
-import flixel.util.FlxPoint;
-import flixel.system.FlxSound;
-import flixel.FlxSprite;
-import flixel.util.FlxMisc;
-import flixel.util.FlxVelocity;
+import org.flixel.FlxG;
+import org.flixel.FlxObject;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxPoint;
+import org.flixel.system.FlxSound;
+import org.flixel.FlxSprite;
+import org.flixel.util.FlxMisc;
+import org.flixel.util.FlxVelocity;
 
 /**
- * 
+ *
  * Makes controlling an FlxSprite with the keyboard a LOT easier and quicker to set-up!<br>
  * Sometimes it's hard to know what values to set, especially if you want gravity, jumping, sliding, etc.<br>
  * This class helps sort that - and adds some cool extra functionality too :)
- * 
+ *
  * TODO: Hot Keys
  * TODO: Binding of sound effects to keys (seperate from setSounds? as those are event based)
  * TODO: If moving diagonally compensate speed parameter (times x,y velocities by 0.707 or cos/sin(45))
  * TODO: Specify animation frames to play based on velocity
  * TODO: Variable gravity (based on height, the higher the stronger the effect)
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
  */
@@ -48,7 +48,7 @@ class FlxControlHandler
 	 * The "Never" Stopping Type means the sprite will never decelerate, any speed built up will be carried on and never reduce.
 	 */
 	inline static public var STOPPING_NEVER:Int = 2;
-	
+
 	/**
 	 * The "Instant" Movement Type means the sprite will rotate at maximum speed instantly, and will not "accelerate" (or speed-up) before reaching that speed.
 	 */
@@ -69,35 +69,35 @@ class FlxControlHandler
 	 * The "Never" Stopping Type means the sprite will never decelerate, any speed built up will be carried on and never reduce.
 	 */
 	inline static public var ROTATION_STOPPING_NEVER:Int = 2;
-	
+
 	/**
 	 * This keymode fires for as long as the key is held down
 	 */
 	inline static public var KEYMODE_PRESSED:Int = 0;
-	
+
 	/**
 	 * This keyboard fires when the key has just been pressed down, and not again until it is released and re-pressed
 	 */
 	inline static public var KEYMODE_JUST_DOWN:Int = 1;
-	
+
 	/**
 	 * This keyboard fires only when the key has been pressed and then released again
 	 */
 	inline static public var KEYMODE_RELEASED:Int = 2;
-	
+
 	// Helpers
 	public var isPressedUp:Bool = false;
 	public var isPressedDown:Bool = false;
 	public var isPressedLeft:Bool = false;
 	public var isPressedRight:Bool = false;
-	
+
 	// Used by the FlxControl plugin
 	public var enabled:Bool = false;
-	
+
 	private var _entity:FlxSprite;
-	
+
 	private var _bounds:Rectangle;
-	
+
 	private var _up:Bool = false;
 	private var _down:Bool = false;
 	private var _left:Bool = false;
@@ -111,14 +111,14 @@ class FlxControlHandler
 	private var _yFacing:Bool;
 	private var _rotateAntiClockwise:Bool;
 	private var _rotateClockwise:Bool;
-	
+
 	private var _upMoveSpeed:Int;
 	private var _downMoveSpeed:Int;
 	private var _leftMoveSpeed:Int;
 	private var _rightMoveSpeed:Int;
 	private var _thrustSpeed:Int;
 	private var _reverseSpeed:Int;
-	
+
 	// Rotation
 	private var _thrustEnabled:Bool = false;
 	private var _reverseEnabled:Bool;
@@ -129,76 +129,76 @@ class FlxControlHandler
 	private var _minAngle:Int;
 	private var _maxAngle:Int;
 	private var _capAngularVelocity:Bool;
-	
+
 	private var _xSpeedAdjust:Float = 0;
 	private var _ySpeedAdjust:Float = 0;
-	
+
 	private var _gravityX:Int = 0;
 	private var _gravityY:Int = 0;
-	
+
 	// The ms delay between firing when the key is held down
-	private var _fireRate:Int; 			
+	private var _fireRate:Int;
 	// The internal time when they can next fire
-	private var _nextFireTime:Int = 0; 		
+	private var _nextFireTime:Int = 0;
 	// The internal time of when when they last fired
-	private var _lastFiredTime:Int; 		
+	private var _lastFiredTime:Int;
 	// The fire key mode
-	private var _fireKeyMode:Int;		
+	private var _fireKeyMode:Int;
 	// A function to call every time they fire
-	private var _fireCallback:Void->Void;	
-	
+	private var _fireCallback:Void->Void;
+
 	// The pixel height amount they jump (drag and gravity also both influence this)
-	private var _jumpHeight:Int; 	
+	private var _jumpHeight:Int;
 	// The ms delay between jumping when the key is held down
-	private var _jumpRate:Int; 	
+	private var _jumpRate:Int;
 	// The jump key mode
 	private var _jumpKeyMode:Int;
 	// The internal time when they can next jump
-	private var _nextJumpTime:Int; 		
+	private var _nextJumpTime:Int;
 	// The internal time of when when they last jumped
-	private var _lastJumpTime:Int; 		
+	private var _lastJumpTime:Int;
 	// A short window of opportunity for them to jump having just fallen off the edge of a surface
-	private var _jumpFromFallTime:Int; 	
+	private var _jumpFromFallTime:Int;
 	// Internal time of when they last collided with a valid jumpSurface
-	private var _extraSurfaceTime:Int; 	
+	private var _extraSurfaceTime:Int;
 	// The surfaces from FlxObject they can jump from (i.e. FlxObject.FLOOR)
-	private var _jumpSurface:Int; 		
+	private var _jumpSurface:Int;
 	// A function to call every time they jump
-	private var _jumpCallback:Void->Void;	
-	
+	private var _jumpCallback:Void->Void;
+
 	private var _movement:Int;
 	private var _stopping:Int;
 	private var _rotation:Int;
 	private var _rotationStopping:Int;
 	private var _capVelocity:Bool;
 	// TODO
-	private var _hotkeys:Array<String>;			
-	
+	private var _hotkeys:Array<String>;
+
 	private var _upKey:String;
 	private var _downKey:String;
 	private var _leftKey:String;
 	private var _rightKey:String;
 	private var _fireKey:String;
 	// TODO
-	private var _altFireKey:String;		
+	private var _altFireKey:String;
 	private var _jumpKey:String;
 	// TODO
-	private var _altJumpKey:String;		
+	private var _altJumpKey:String;
 	private var _antiClockwiseKey:String;
 	private var _clockwiseKey:String;
 	private var _thrustKey:String;
 	private var _reverseKey:String;
-	
+
 	// Sounds
 	private var _jumpSound:FlxSound;
 	private var _fireSound:FlxSound;
 	private var _walkSound:FlxSound;
 	private var _thrustSound:FlxSound;
-	
+
 	/**
 	 * Sets the FlxSprite to be controlled by this class, and defines the initial movement and stopping types.<br>
 	 * After creating an instance of this class you should call setMovementSpeed, and one of the enableXControl functions if you need more than basic cursors.
-	 * 
+	 *
 	 * @param	Sprite			The FlxSprite you want this class to control. It can only control one FlxSprite at once.
 	 * @param	MovementType	Set to either MOVEMENT_INSTANT or MOVEMENT_ACCELERATES
 	 * @param	StoppingType	Set to STOPPING_INSTANT, STOPPING_DECELERATES or STOPPING_NEVER
@@ -208,31 +208,31 @@ class FlxControlHandler
 	public function new(Sprite:FlxSprite, MovementType:Int, StoppingType:Int, UpdateFacing:Bool = false, EnableArrowKeys:Bool = true)
 	{
 		_entity = Sprite;
-		
+
 		_movement = MovementType;
 		_stopping = StoppingType;
-		
+
 		_xFacing = UpdateFacing;
 		_yFacing = UpdateFacing;
-		
+
 		_rotation = ROTATION_INSTANT;
 		_rotationStopping = ROTATION_STOPPING_INSTANT;
-		
+
 		if (EnableArrowKeys)
 		{
 			setCursorControl();
 		}
-		
+
 		enabled = true;
 	}
-	
+
 	/**
 	 * Set the speed at which the sprite will move when a direction key is pressed.<br>
 	 * All values are given in pixels per second. So an xSpeed of 100 would move the sprite 100 pixels in 1 second (1000ms)
 	 * Due to the nature of the internal Flash timer this amount is not 100% accurate and will vary above/below the desired distance by a few pixels.
-	 * 
+	 *
 	 * If you need different speed values for left/right or up/down then use setAdvancedMovementSpeed
-	 * 
+	 *
 	 * @param	SpeedX			The speed in pixels per second in which the sprite will move/accelerate horizontally
 	 * @param	SpeedY			The speed in pixels per second in which the sprite will move/accelerate vertically
 	 * @param	SpeedMaxX		The maximum speed in pixels per second in which the sprite can move horizontally
@@ -246,14 +246,14 @@ class FlxControlHandler
 		_rightMoveSpeed = SpeedX;
 		_upMoveSpeed = - SpeedY;
 		_downMoveSpeed = SpeedY;
-		
+
 		setMaximumSpeed(SpeedMaxX, SpeedMaxY);
 		setDeceleration(DecelerationX, DecelerationY);
 	}
-	
+
 	/**
 	 * If you know you need the same value for the acceleration, maximum speeds and (optionally) deceleration then this is a quick way to set them.
-	 * 
+	 *
 	 * @param	Speed			The speed in pixels per second in which the sprite will move/accelerate/decelerate
 	 * @param	Acceleration	If true it will set the speed value as the deceleration value (default) false will leave deceleration disabled
 	 */
@@ -268,14 +268,14 @@ class FlxControlHandler
 			setMovementSpeed(Speed, Speed, Speed, Speed);
 		}
 	}
-	
+
 	/**
 	 * Set the speed at which the sprite will move when a direction key is pressed.<br>
 	 * All values are given in pixels per second. So an xSpeed of 100 would move the sprite 100 pixels in 1 second (1000ms)<br>
 	 * Due to the nature of the internal Flash timer this amount is not 100% accurate and will vary above/below the desired distance by a few pixels.<br>
-	 * 
+	 *
 	 * If you don't need different speed values for every direction on its own then use setMovementSpeed
-	 * 
+	 *
 	 * @param	LeftSpeed		The speed in pixels per second in which the sprite will move/accelerate to the left
 	 * @param	RightSpeed		The speed in pixels per second in which the sprite will move/accelerate to the right
 	 * @param	UpSpeed			The speed in pixels per second in which the sprite will move/accelerate up
@@ -291,11 +291,11 @@ class FlxControlHandler
 		_rightMoveSpeed = RightSpeed;
 		_upMoveSpeed = - UpSpeed;
 		_downMoveSpeed = DownSpeed;
-		
+
 		setMaximumSpeed(SpeedMaxX, SpeedMaxY);
 		setDeceleration(DecelerationX, DecelerationY);
 	}
-	
+
 	/**
 	 * Set the speed at which the sprite will rotate when a direction key is pressed.<br>
 	 * Use this in combination with setMovementSpeed to create a Thrust like movement system.<br>
@@ -306,12 +306,12 @@ class FlxControlHandler
 	{
 		_antiClockwiseRotationSpeed = -AntiClockwiseSpeed;
 		_clockwiseRotationSpeed = ClockwiseSpeed;
-		
+
 		setRotationKeys();
 		setMaximumRotationSpeed(SpeedMax);
 		setRotationDeceleration(Deceleration);
 	}
-	
+
 	/**
 	 * @param	RotationType
 	 * @param	StoppingType
@@ -321,37 +321,37 @@ class FlxControlHandler
 		_rotation = RotationType;
 		_rotationStopping = StoppingType;
 	}
-	
+
 	/**
 	 * Sets the maximum speed (in pixels per second) that the FlxSprite can rotate.<br>
 	 * When the FlxSprite is accelerating (movement type MOVEMENT_ACCELERATES) its speed won't increase above this value.<br>
 	 * However Flixel allows the velocity of an FlxSprite to be set to anything. So if you'd like to check the value and restrain it, then enable "limitVelocity".
-	 * 
+	 *
 	 * @param	Speed			The maximum speed in pixels per second in which the sprite can rotate
 	 * @param	LimitVelocity	If true the angular velocity of the FlxSprite will be checked and kept within the limit. If false it can be set to anything.
 	 */
 	public function setMaximumRotationSpeed(Speed:Float, LimitVelocity:Bool = true):Void
 	{
 		_entity.maxAngular = Speed;
-		
+
 		_capAngularVelocity = LimitVelocity;
 	}
-	
+
 	/**
 	 * Deceleration is a speed (in pixels per second) that is applied to the sprite if stopping type is "DECELERATES" and if no rotation is taking place.<br>
 	 * The velocity of the sprite will be reduced until it reaches zero.
-	 * 
+	 *
 	 * @param	Speed	The speed in pixels per second at which the sprite will have its angular rotation speed decreased
 	 */
 	public function setRotationDeceleration(Speed:Float):Void
 	{
 		_entity.angularDrag = Speed;
 	}
-	
+
 	/**
 	 * Set minimum and maximum angle limits that the Sprite won't be able to rotate beyond.<br>
 	 * Values must be between -180 and +180. 0 is pointing right, 90 down, 180 left, -90 up.
-	 * 
+	 *
 	 * @param	MinimumAngle	Minimum angle below which the sprite cannot rotate (must be -180 or above)
 	 * @param	MaximumAngle	Maximum angle above which the sprite cannot rotate (must be 180 or below)
 	 */
@@ -368,7 +368,7 @@ class FlxControlHandler
 			_maxAngle = MaximumAngle;
 		}
 	}
-	
+
 	/**
 	 * Disables rotation limits set in place by setRotationLimits()
 	 */
@@ -376,10 +376,10 @@ class FlxControlHandler
 	{
 		_enforceAngleLimits = false;
 	}
-	
+
 	/**
 	 * Set which keys will rotate the sprite. The speed of rotation is set in setRotationSpeed.
-	 * 
+	 *
 	 * @param	LeftRight				Use the LEFT and RIGHT arrow keys for anti-clockwise and clockwise rotation respectively.
 	 * @param	UpDown					Use the UP and DOWN arrow keys for anti-clockwise and clockwise rotation respectively.
 	 * @param	CustomAntiClockwise		The String value of your own key to use for anti-clockwise rotation (as taken from flixel.system.input.Keyboard)
@@ -398,18 +398,18 @@ class FlxControlHandler
 			_antiClockwiseKey = "UP";
 			_clockwiseKey = "DOWN";
 		}
-		
+
 		if (CustomAntiClockwise != "" && CustomClockwise != "")
 		{
 			_antiClockwiseKey = CustomAntiClockwise;
 			_clockwiseKey = CustomClockwise;
 		}
 	}
-	
+
 	/**
 	 * If you want to enable a Thrust like motion for your sprite use this to set the speed and keys.<br>
 	 * This is usually used in conjunction with Rotation and it will over-ride anything already defined in setMovementSpeed.
-	 * 
+	 *
 	 * @param	ThrustKey		Specify the key String (as taken from flixel.system.input.Keyboard) to use for the Thrust action
 	 * @param	ThrustSpeed		The speed in pixels per second which the sprite will move. Acceleration or Instant movement is determined by the Movement Type.
 	 * @param	ReverseKey		If you want to be able to reverse, set the key string as taken from flixel.system.input.Keyboard (defaults to null).
@@ -419,14 +419,14 @@ class FlxControlHandler
 	{
 		_thrustEnabled = false;
 		_reverseEnabled = false;
-		
+
 		if (ThrustKey != "")
 		{
 			_thrustKey = ThrustKey;
 			_thrustSpeed = Math.floor(ThrustSpeed);
 			_thrustEnabled = true;
 		}
-		
+
 		if (ReverseKey != null)
 		{
 			_reverseKey = ReverseKey;
@@ -434,12 +434,12 @@ class FlxControlHandler
 			_reverseEnabled = true;
 		}
 	}
-	
+
 	/**
 	 * Sets the maximum speed (in pixels per second) that the FlxSprite can move. You can set the horizontal and vertical speeds independantly.<br>
 	 * When the FlxSprite is accelerating (movement type MOVEMENT_ACCELERATES) its speed won't increase above this value.<br>
 	 * However Flixel allows the velocity of an FlxSprite to be set to anything. So if you'd like to check the value and restrain it, then enable "limitVelocity".
-	 * 
+	 *
 	 * @param	SpeedX			The maximum speed in pixels per second in which the sprite can move horizontally
 	 * @param	SpeedY			The maximum speed in pixels per second in which the sprite can move vertically
 	 * @param	LimitVelocity	If true the velocity of the FlxSprite will be checked and kept within the limit. If false it can be set to anything.
@@ -448,14 +448,14 @@ class FlxControlHandler
 	{
 		_entity.maxVelocity.x = SpeedX;
 		_entity.maxVelocity.y = SpeedY;
-		
+
 		_capVelocity = LimitVelocity;
 	}
-	
+
 	/**
 	 * Deceleration is a speed (in pixels per second) that is applied to the sprite if stopping type is "DECELERATES" and if no acceleration is taking place.<br>
 	 * The velocity of the sprite will be reduced until it reaches zero, and can be configured separately per axis.
-	 * 
+	 *
 	 * @param	SpeedX		The speed in pixels per second at which the sprite will have its horizontal speed decreased
 	 * @param	SpeedY		The speed in pixels per second at which the sprite will have its vertical speed decreased
 	 */
@@ -464,12 +464,12 @@ class FlxControlHandler
 		_entity.drag.x = SpeedX;
 		_entity.drag.y = SpeedY;
 	}
-	
+
 	/**
 	 * Gravity can be applied to the sprite, pulling it in any direction.<br>
 	 * Gravity is given in pixels per second and is applied as acceleration. The speed the sprite reaches under gravity will never exceed the Maximum Movement Speeds set.<br>
 	 * If you don't want gravity for a specific direction pass a value of zero.
-	 * 
+	 *
 	 * @param	ForceX	A positive value applies gravity dragging the sprite to the right. A negative value drags the sprite to the left. Zero disables horizontal gravity.
 	 * @param	ForceY	A positive value applies gravity dragging the sprite down. A negative value drags the sprite up. Zero disables vertical gravity.
 	 */
@@ -477,11 +477,11 @@ class FlxControlHandler
 	{
 		_gravityX = ForceX;
 		_gravityY = ForceY;
-		
+
 		_entity.acceleration.x = _gravityX;
 		_entity.acceleration.y = _gravityY;
 	}
-	
+
 	/**
 	 * Switches the gravity applied to the sprite. If gravity was +400 Y (pulling them down) this will swap it to -400 Y (pulling them up)<br>
 	 * To reset call flipGravity again
@@ -493,37 +493,37 @@ class FlxControlHandler
 			_gravityX = - _gravityX;
 			_entity.acceleration.x = _gravityX;
 		}
-		
+
 		if (!Math.isNaN(_gravityY) && _gravityY != 0)
 		{
 			_gravityY = - _gravityY;
 			_entity.acceleration.y = _gravityY;
 		}
 	}
-	
+
 	/**
 	 * TODO
-	 * 
+	 *
 	 * @param	FactorX
 	 * @param	FactorY
 	 */
 	public function speedUp(FactorX:Float, FactorY:Float):Void
 	{
 	}
-	
+
 	/**
 	 * TODO
-	 * 
+	 *
 	 * @param	FactorX
 	 * @param	FactorY
 	 */
 	public function slowDown(FactorX:Float, FactorY:Float):Void
 	{
 	}
-	
+
 	/**
 	 * TODO
-	 * 
+	 *
 	 * @param	ResetX
 	 * @param	ResetY
 	 */
@@ -533,16 +533,16 @@ class FlxControlHandler
 		{
 			_xSpeedAdjust = 0;
 		}
-		
+
 		if (ResetY)
 		{
 			_ySpeedAdjust = 0;
 		}
 	}
-	
+
 	/**
 	 * Creates a new Hot Key, which can be bound to any function you specify (such as "swap weapon", "quit", etc)
-	 * 
+	 *
 	 * @param	Key			The key to use as the hot key (String from flixel.system.input.Keyboard, i.e. "SPACE", "CONTROL", "Q", etc)
 	 * @param	Callback	The function to call when the key is pressed
 	 * @param	Keymode		The keymode that will trigger the callback, either KEYMODE_PRESSED, KEYMODE_JUST_DOWN or KEYMODE_RELEASED
@@ -551,10 +551,10 @@ class FlxControlHandler
 	{
 		// TODO
 	}
-	
+
 	/**
 	 * Removes a previously defined hot key
-	 * 
+	 *
 	 * @param	Key		The key to use as the hot key (String from flixel.system.input.Keyboard, i.e. "SPACE", "CONTROL", "Q", etc)
 	 * @return	True if the key was found and removed, false if the key couldn't be found
 	 */
@@ -562,10 +562,10 @@ class FlxControlHandler
 	{
 		return true;
 	}
-	
+
 	/**
 	 * Set sound effects for the movement events jumping, firing, walking and thrust.
-	 * 
+	 *
 	 * @param	Jump	The FlxSound to play when the user jumps
 	 * @param	Fire	The FlxSound to play when the user fires
 	 * @param	Walk	The FlxSound to play when the user walks
@@ -577,26 +577,26 @@ class FlxControlHandler
 		{
 			_jumpSound = Jump;
 		}
-		
+
 		if (Fire != null)
 		{
 			_fireSound = Fire;
 		}
-		
+
 		if (Walk != null)
 		{
 			_walkSound = Walk;
 		}
-		
+
 		if (Thrust != null)
 		{
 			_thrustSound = Thrust;
 		}
 	}
-	
+
 	/**
 	 * Enable a fire button
-	 * 
+	 *
 	 * @param	Key				The key to use as the fire button (String from flixel.system.input.Keyboard, i.e. "SPACE", "CONTROL")
 	 * @param	Keymode			The FlxControlHandler KEYMODE value (KEYMODE_PRESSED, KEYMODE_JUST_DOWN, KEYMODE_RELEASED)
 	 * @param	RepeatDelay		Time delay in ms between which the fire action can repeat (0 means instant, 250 would allow it to fire approx. 4 times per second)
@@ -609,18 +609,18 @@ class FlxControlHandler
 		_fireKeyMode = Keymode;
 		_fireRate = RepeatDelay;
 		_fireCallback = Callback;
-		
+
 		if (AltKey != "")
 		{
 			_altFireKey = AltKey;
 		}
-		
+
 		_fire = true;
 	}
-	
+
 	/**
 	 * Enable a jump button
-	 * 
+	 *
 	 * @param	Key				The key to use as the jump button (String from flixel.system.input.Keyboard, i.e. "SPACE", "CONTROL")
 	 * @param	Keymode			The FlxControlHandler KEYMODE value (KEYMODE_PRESSED, KEYMODE_JUST_DOWN, KEYMODE_RELEASED)
 	 * @param	Height			The height in pixels/sec that the Sprite will attempt to jump (gravity and acceleration can influence this actual height obtained)
@@ -639,19 +639,19 @@ class FlxControlHandler
 		_jumpRate = RepeatDelay;
 		_jumpFromFallTime = JumpFromFall;
 		_jumpCallback = Callback;
-		
+
 		if (AltKey != "")
 		{
 			_altJumpKey = AltKey;
 		}
-		
+
 		_jump = true;
 	}
-	
+
 	/**
 	 * Limits the sprite to only be allowed within this rectangle. If its x/y coordinates go outside it will be repositioned back inside.
 	 * Coordinates should be given in GAME WORLD pixel values (not screen value, although often they are the two same things)
-	 * 
+	 *
 	 * @param	X		The x coordinate of the top left corner of the area (in game world pixels)
 	 * @param	Y		The y coordinate of the top left corner of the area (in game world pixels)
 	 * @param	Width	The width of the area (in pixels)
@@ -661,7 +661,7 @@ class FlxControlHandler
 	{
 		_bounds = new Rectangle(X, Y, Width, Height);
 	}
-	
+
 	/**
 	 * Clears any previously set sprite bounds
 	 */
@@ -669,21 +669,21 @@ class FlxControlHandler
 	{
 		_bounds = null;
 	}
-	
+
 	private function moveUp():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_upKey))
 		{
 			move = true;
 			isPressedUp = true;
-			
+
 			if (_yFacing)
 			{
 				_entity.facing = FlxObject.UP;
 			}
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.y = _upMoveSpeed;
@@ -692,30 +692,30 @@ class FlxControlHandler
 			{
 				_entity.acceleration.y = _upMoveSpeed;
 			}
-			
+
 			if (_bounds != null && _entity.y < _bounds.top)
 			{
 				_entity.y = _bounds.top;
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveDown():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_downKey))
 		{
 			move = true;
 			isPressedDown = true;
-			
+
 			if (_yFacing)
 			{
 				_entity.facing = FlxObject.DOWN;
 			}
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.y = _downMoveSpeed;
@@ -724,31 +724,31 @@ class FlxControlHandler
 			{
 				_entity.acceleration.y = _downMoveSpeed;
 			}
-			
+
 			if (_bounds != null && _entity.y > _bounds.bottom)
 			{
 				_entity.y = _bounds.bottom;
 			}
-			
+
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveLeft():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_leftKey))
 		{
 			move = true;
 			isPressedLeft = true;
-			
+
 			if (_xFacing)
 			{
 				_entity.facing = FlxObject.LEFT;
 			}
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.x = _leftMoveSpeed;
@@ -757,30 +757,30 @@ class FlxControlHandler
 			{
 				_entity.acceleration.x = _leftMoveSpeed;
 			}
-			
+
 			if (_bounds != null && _entity.x < _bounds.x)
 			{
 				_entity.x = _bounds.x;
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveRight():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_rightKey))
 		{
 			move = true;
 			isPressedRight = true;
-			
+
 			if (_xFacing)
 			{
 				_entity.facing = FlxObject.RIGHT;
 			}
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.x = _rightMoveSpeed;
@@ -789,24 +789,24 @@ class FlxControlHandler
 			{
 				_entity.acceleration.x = _rightMoveSpeed;
 			}
-			
+
 			if (_bounds != null && _entity.x > _bounds.right)
 			{
 				_entity.x = _bounds.right;
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveAntiClockwise():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_antiClockwiseKey))
 		{
 			move = true;
-			
+
 			if (_rotation == ROTATION_INSTANT)
 			{
 				_entity.angularVelocity = _antiClockwiseRotationSpeed;
@@ -815,25 +815,25 @@ class FlxControlHandler
 			{
 				_entity.angularAcceleration = _antiClockwiseRotationSpeed;
 			}
-			
+
 			// TODO - Not quite there yet given the way Flixel can rotate to any valid int angle!
 			if (_enforceAngleLimits)
 			{
 				//entity.angle = FlxAngle.angleLimit(entity.angle, minAngle, maxAngle);
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveClockwise():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_clockwiseKey))
 		{
 			move = true;
-			
+
 			if (_rotation == ROTATION_INSTANT)
 			{
 				_entity.angularVelocity = _clockwiseRotationSpeed;
@@ -842,27 +842,27 @@ class FlxControlHandler
 			{
 				_entity.angularAcceleration = _clockwiseRotationSpeed;
 			}
-			
+
 			// TODO - Not quite there yet given the way Flixel can rotate to any valid int angle!
 			if (_enforceAngleLimits)
 			{
 				//entity.angle = FlxAngle.angleLimit(entity.angle, minAngle, maxAngle);
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveThrust():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_thrustKey))
 		{
 			move = true;
-			
+
 			var motion:FlxPoint = FlxVelocity.velocityFromAngle(Math.floor(_entity.angle), _thrustSpeed);
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.x = motion.x;
@@ -873,31 +873,31 @@ class FlxControlHandler
 				_entity.acceleration.x = motion.x;
 				_entity.acceleration.y = motion.y;
 			}
-			
+
 			if (_bounds != null && _entity.x < _bounds.x)
 			{
 				_entity.x = _bounds.x;
 			}
 		}
-		
+
 		if (move && _thrustSound != null)
 		{
 			_thrustSound.play(false);
 		}
-		
+
 		return move;
 	}
-	
+
 	private function moveReverse():Bool
 	{
 		var move:Bool = false;
-		
+
 		if (FlxG.keyboard.pressed(_reverseKey))
 		{
 			move = true;
-			
+
 			var motion:FlxPoint = FlxVelocity.velocityFromAngle(Math.floor(_entity.angle), _reverseSpeed);
-			
+
 			if (_movement == MOVEMENT_INSTANT)
 			{
 				_entity.velocity.x = -motion.x;
@@ -908,20 +908,20 @@ class FlxControlHandler
 				_entity.acceleration.x = -motion.x;
 				_entity.acceleration.y = -motion.y;
 			}
-			
+
 			if (_bounds != null && _entity.x < _bounds.x)
 			{
 				_entity.x = _bounds.x;
 			}
 		}
-		
+
 		return move;
 	}
-	
+
 	private function runFire():Bool
 	{
 		var fired:Bool = false;
-		
+
 		// 0 = Pressed
 		// 1 = Just Down
 		// 2 = Just Released
@@ -944,25 +944,25 @@ class FlxControlHandler
 				fired = true;
 			}
 		}
-		
+
 		if (fired && _fireSound != null)
 		{
 			_fireSound.play(true);
 		}
-		
+
 		return fired;
 	}
-	
+
 	private function runJump():Bool
 	{
 		var jumped:Bool = false;
-		
+
 		// This should be called regardless if they've pressed jump or not
 		if (_entity.isTouching(_jumpSurface))
 		{
 			_extraSurfaceTime = FlxG.game.ticks + _jumpFromFallTime;
 		}
-		
+
 		if ((_jumpKeyMode == KEYMODE_PRESSED && FlxG.keyboard.pressed(_jumpKey)) || (_jumpKeyMode == KEYMODE_JUST_DOWN && FlxG.keyboard.justPressed(_jumpKey)) || (_jumpKeyMode == KEYMODE_RELEASED && FlxG.keyboard.justReleased(_jumpKey)))
 		{
 			// Sprite not touching a valid jump surface
@@ -981,7 +981,7 @@ class FlxControlHandler
 						return jumped;
 					}
 				}
-				
+
 				// If there is a jump repeat rate set and we're still less than it then return
 				if (FlxG.game.ticks < _nextJumpTime)
 				{
@@ -996,7 +996,7 @@ class FlxControlHandler
 					return jumped;
 				}
 			}
-			
+
 			if (_gravityY > 0)
 			{
 				// Gravity is pulling them down to earth, so they are jumping up (negative)
@@ -1007,26 +1007,26 @@ class FlxControlHandler
 				// Gravity is pulling them up, so they are jumping down (positive)
 				_entity.velocity.y = _jumpHeight;
 			}
-			
+
 			if (_jumpCallback != null)
 			{
 				_jumpCallback();
 			}
-			
+
 			_lastJumpTime = FlxG.game.ticks;
 			_nextJumpTime = _lastJumpTime + Std.int(_jumpRate / FlxG.timeScale);
-			
+
 			jumped = true;
 		}
-		
+
 		if (jumped && _jumpSound != null)
 		{
 			_jumpSound.play(true);
 		}
-		
+
 		return jumped;
 	}
-	
+
 	/**
 	 * Called by the FlxControl plugin
 	 */
@@ -1036,13 +1036,13 @@ class FlxControlHandler
 		{
 			return;
 		}
-		
+
 		// Reset the helper booleans
 		isPressedUp = false;
 		isPressedDown = false;
 		isPressedLeft = false;
 		isPressedRight = false;
-		
+
 		if (_stopping == STOPPING_INSTANT)
 		{
 			if (_movement == MOVEMENT_INSTANT)
@@ -1070,7 +1070,7 @@ class FlxControlHandler
 				_entity.acceleration.y = _gravityY;
 			}
 		}
-		
+
 		// Rotation
 		if (_isRotating)
 		{
@@ -1092,17 +1092,17 @@ class FlxControlHandler
 					_entity.angularVelocity = 0;
 				}
 			}
-			
+
 			var hasRotatedAntiClockwise:Bool = false;
 			var hasRotatedClockwise:Bool = false;
-			
+
 			hasRotatedAntiClockwise = moveAntiClockwise();
-			
+
 			if (hasRotatedAntiClockwise == false)
 			{
 				hasRotatedClockwise = moveClockwise();
 			}
-			
+
 			if (_rotationStopping == ROTATION_STOPPING_DECELERATES)
 			{
 				if (_rotation == ROTATION_ACCELERATES && hasRotatedAntiClockwise == false && hasRotatedClockwise == false)
@@ -1110,7 +1110,7 @@ class FlxControlHandler
 					_entity.angularAcceleration = 0;
 				}
 			}
-			
+
 			// If they have got instant stopping with acceleration and are NOT pressing a key, then stop the rotation. Otherwise we let it carry on
 			if (_rotationStopping == ROTATION_STOPPING_INSTANT && _rotation == ROTATION_ACCELERATES && hasRotatedAntiClockwise == false && hasRotatedClockwise == false)
 			{
@@ -1118,17 +1118,17 @@ class FlxControlHandler
 				_entity.angularAcceleration = 0;
 			}
 		}
-		
+
 		// Thrust
 		if (_thrustEnabled || _reverseEnabled)
 		{
 			var moved:Bool = false;
-			
+
 			if (_thrustEnabled)
 			{
 				moved = moveThrust();
 			}
-			
+
 			if (moved == false && _reverseEnabled)
 			{
 				moved = moveReverse();
@@ -1138,51 +1138,51 @@ class FlxControlHandler
 		{
 			var movedX:Bool = false;
 			var movedY:Bool = false;
-			
+
 			if (_up)
 			{
 				movedY = moveUp();
 			}
-			
+
 			if (_down && movedY == false)
 			{
 				movedY = moveDown();
 			}
-			
+
 			if (_left)
 			{
 				movedX = moveLeft();
 			}
-			
+
 			if (_right && movedX == false)
 			{
 				movedX = moveRight();
 			}
 		}
-		
+
 		if (_fire)
 		{
 			runFire();
 		}
-		
+
 		if (_jump)
 		{
 			runJump();
 		}
-		
+
 		if (_capVelocity)
 		{
 			if (_entity.velocity.x > _entity.maxVelocity.x)
 			{
 				_entity.velocity.x = _entity.maxVelocity.x;
 			}
-			
+
 			if (_entity.velocity.y > _entity.maxVelocity.y)
 			{
 				_entity.velocity.y = _entity.maxVelocity.y;
 			}
 		}
-		
+
 		if (_walkSound != null)
 		{
 			if ((_movement == MOVEMENT_INSTANT && _entity.velocity.x != 0) || (_movement == MOVEMENT_ACCELERATES && _entity.acceleration.x != 0))
@@ -1195,11 +1195,11 @@ class FlxControlHandler
 			}
 		}
 	}
-	
+
 	/**
 	 * Sets Custom Key controls. Useful if none of the pre-defined sets work. All String values should be taken from flixel.system.input.Keyboard
 	 * Pass a blank (empty) String to disable that key from being checked.
-	 * 
+	 *
 	 * @param	CustomUpKey		The String to use for the Up key.
 	 * @param	CustomDownKey	The String to use for the Down key.
 	 * @param	CustomLeftKey	The String to use for the Left key.
@@ -1212,30 +1212,30 @@ class FlxControlHandler
 			_up = true;
 			_upKey = CustomUpKey;
 		}
-		
+
 		if (CustomDownKey != "")
 		{
 			_down = true;
 			_downKey = CustomDownKey;
 		}
-		
+
 		if (CustomLeftKey != "")
 		{
 			_left = true;
 			_leftKey = CustomLeftKey;
 		}
-		
+
 		if (CustomRightKey != "")
 		{
 			_right = true;
 			_rightKey = CustomRightKey;
 		}
 	}
-	
+
 	/**
 	 * Enables Cursor/Arrow Key controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the UP key
 	 * @param	AllowDown	Enable the DOWN key
 	 * @param	AllowLeft	Enable the LEFT key
@@ -1247,17 +1247,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "UP";
 		_downKey = "DOWN";
 		_leftKey = "LEFT";
 		_rightKey = "RIGHT";
 	}
-	
+
 	/**
 	 * Enables WASD controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	allowUp		Enable the up (W) key
 	 * @param	allowDown	Enable the down (S) key
 	 * @param	allowLeft	Enable the left (A) key
@@ -1269,17 +1269,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "W";
 		_downKey = "S";
 		_leftKey = "A";
 		_rightKey = "D";
 	}
-	
+
 	/**
 	 * Enables ESDF (home row) controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (E) key
 	 * @param	AllowDown	Enable the down (D) key
 	 * @param	AllowLeft	Enable the left (S) key
@@ -1291,17 +1291,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "E";
 		_downKey = "D";
 		_leftKey = "S";
 		_rightKey = "F";
 	}
-	
+
 	/**
 	 * Enables IJKL (right-sided or secondary player) controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (I) key
 	 * @param	AllowDown	Enable the down (K) key
 	 * @param	AllowLeft	Enable the left (J) key
@@ -1313,17 +1313,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "I";
 		_downKey = "K";
 		_leftKey = "J";
 		_rightKey = "L";
 	}
-	
+
 	/**
 	 * Enables HJKL (Rogue / Net-Hack) controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (K) key
 	 * @param	AllowDown	Enable the down (J) key
 	 * @param	AllowLeft	Enable the left (H) key
@@ -1335,17 +1335,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "K";
 		_downKey = "J";
 		_leftKey = "H";
 		_rightKey = "L";
 	}
-	
+
 	/**
 	 * Enables ZQSD (Azerty keyboard) controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (Z) key
 	 * @param	AllowDown	Enable the down (Q) key
 	 * @param	AllowLeft	Enable the left (S) key
@@ -1357,17 +1357,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "Z";
 		_downKey = "S";
 		_leftKey = "Q";
 		_rightKey = "D";
 	}
-	
+
 	/**
 	 * Enables Dvoark Simplified Controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.<br>
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (COMMA) key
 	 * @param	AllowDown	Enable the down (A) key
 	 * @param	AllowLeft	Enable the left (O) key
@@ -1379,17 +1379,17 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "COMMA";
 		_downKey = "O";
 		_leftKey = "A";
 		_rightKey = "E";
 	}
-	
+
 	/**
 	 * Enables Numpad (left-handed) Controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
-	 * 
+	 *
 	 * @param	AllowUp		Enable the up (NUMPADEIGHT) key
 	 * @param	AllowDown	Enable the down (NUMPADTWO) key
 	 * @param	AllowLeft	Enable the left (NUMPADFOUR) key
@@ -1401,7 +1401,7 @@ class FlxControlHandler
 		_down = AllowDown;
 		_left = AllowLeft;
 		_right = AllowRight;
-		
+
 		_upKey = "NUMPADEIGHT";
 		_downKey = "NUMPADTWO";
 		_leftKey = "NUMPADFOUR";

--- a/flixel/addons/plugin/effects/FlxSpecialFX.hx
+++ b/flixel/addons/plugin/effects/FlxSpecialFX.hx
@@ -2,26 +2,26 @@ package flixel.addons.plugin.effects;
 
 import flixel.addons.plugin.effects.fx.BaseFX;
 import flixel.addons.plugin.effects.fx.StarfieldFX;
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.plugin.FlxPlugin;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.plugin.FlxPlugin;
 import haxe.ds.ObjectMap;
 
 /**
  * FlxSpecialFX is a single point of access to all of the FX Plugins available in the Flixel Power Tools
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
  */
 class FlxSpecialFX extends FlxPlugin
 {
 	static private var members:ObjectMap<BaseFX, BaseFX> = new ObjectMap<BaseFX, BaseFX>();
-	
+
 	// THE SPECIAL FX PLUGINS AVAILABLE
-	
+
 	/**
 	 * Creates a Glitch Effect
-	 * 
+	 *
 	 * @return	GlitchFX
 	 */
 	/*public static function glitch():GlitchFX
@@ -30,10 +30,10 @@ class FlxSpecialFX extends FlxPlugin
 		members.set(temp, temp);
 		return temp;
 	}*/
-	
+
 	/**
 	 * Creates a 2D or 3D Starfield Effect
-	 * 
+	 *
 	 * @return	StarfieldFX
 	 */
 	public static function starfield():StarfieldFX
@@ -43,12 +43,12 @@ class FlxSpecialFX extends FlxPlugin
 
 		return temp;
 	}
-	
+
 	//	GLOBAL FUNCTIONS
-	
+
 	/**
 	 * Starts the given FX Plugin running
-	 * 
+	 *
 	 * @param	Effect	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
 	 */
 	public static function startFX(?Effect:BaseFX):Void
@@ -65,10 +65,10 @@ class FlxSpecialFX extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Stops the given FX Plugin running
-	 * 
+	 *
 	 * @param	Effect	A reference to the FX Plugin you wish to stop. If null it will stop all currently added FX Plugins
 	 */
 	public static function stopFX(?Effect:BaseFX):Void
@@ -85,10 +85,10 @@ class FlxSpecialFX extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Returns the active state of the given FX Plugin running
-	 * 
+	 *
 	 * @param	Effect	A reference to the FX Plugin you wish to run. If null it will start all currently added FX Plugins
 	 * @return	Boolean	true if the FX Plugin is active, false if not
 	 */
@@ -98,10 +98,10 @@ class FlxSpecialFX extends FlxPlugin
 		{
 			return members.get(Effect).active;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Called automatically by Flixels Plugin handler
 	 */
@@ -111,7 +111,7 @@ class FlxSpecialFX extends FlxPlugin
 		{
 			return;
 		}
-		
+
 		for (obj in members)
 		{
 			if (obj.active)
@@ -120,10 +120,10 @@ class FlxSpecialFX extends FlxPlugin
 			}
 		}
 	}
-	
+
 	/**
 	 * Removes a FX Plugin from the Special FX Handler
-	 * 
+	 *
 	 * @param	Effect	The FX Plugin to remove
 	 * @return	Boolean	true if the plugin was removed, otherwise false.
 	 */
@@ -133,15 +133,15 @@ class FlxSpecialFX extends FlxPlugin
 		{
 			members.get(Effect).destroy();
 			members.remove(Effect);
-			
+
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
-	 * Removes all FX Plugins. This is called automatically if the plugin is destroyed, 
+	 * Removes all FX Plugins. This is called automatically if the plugin is destroyed,
 	 * but should be called manually by you if you change states.
 	 */
 	public static function clear():Void
@@ -151,7 +151,7 @@ class FlxSpecialFX extends FlxPlugin
 			remove(obj);
 		}
 	}
-	
+
 	/**
 	 * Destroys all FX Plugins currently added and then destroys this instance of the FlxSpecialFX Plugin
 	 */

--- a/flixel/addons/plugin/effects/fx/StarfieldFX.hx
+++ b/flixel/addons/plugin/effects/fx/StarfieldFX.hx
@@ -3,21 +3,21 @@ package flixel.addons.plugin.effects.fx;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.FlxG;
-import flixel.FlxSprite;
-import flixel.util.FlxAngle;
-import flixel.util.FlxColor;
-import flixel.util.FlxColorUtil;
-import flixel.util.FlxGradient;
-import flixel.util.FlxMisc;
-import flixel.system.layer.DrawStackItem;
-import flixel.system.layer.Region;
-import flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.FlxSprite;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxColor;
+import org.flixel.util.FlxColorUtil;
+import org.flixel.util.FlxGradient;
+import org.flixel.util.FlxMisc;
+import org.flixel.system.layer.DrawStackItem;
+import org.flixel.system.layer.Region;
+import org.flixel.FlxBasic;
 
 
 /**
  * Creates a 2D or 3D Star Field effect on an FlxSprite for use in your game.
- * 
+ *
  * //todo Neko target is unsupported, possible issue with tilesize
  *
  * @link http://www.photonstorm.com
@@ -27,7 +27,7 @@ class StarfieldFX extends BaseFX
 {
 	inline static public var STARFIELD_TYPE_2D:Int = 1;
 	inline static public var STARFIELD_TYPE_3D:Int = 2;
-	
+
 	/**
 	 * In a 3D starfield this controls the X coordinate the stars emit from, can be updated in real-time!
 	 */
@@ -44,27 +44,27 @@ class StarfieldFX extends BaseFX
 	 * How much to shift on the Y axis every update. Negative values move up, positiive values move down. 2D Starfield only. Can also be set via setStarSpeed()
 	 */
 	public var starYOffset:Float = 0;
-	
+
 	private var _stars:Array<StarObject>;
 	private var _starfieldType:Int;
-	
+
 	private var _backgroundColor:Int;
-	
+
 	private var _updateSpeed:Int;
 	private var _tick:Int;
-	
+
 	private var _depthColours:Array<Int>;
-	
-	public function new() 
+
+	public function new()
 	{
 		super();
-		
+
 		_backgroundColor = FlxColor.BLACK;
 	}
-	
+
 	/**
 	 * Create a new StarField
-	 * 
+	 *
 	 * @param	X				X coordinate of the starfield sprite
 	 * @param	Y				Y coordinate of the starfield sprite
 	 * @param	Width			The width of the starfield
@@ -84,26 +84,26 @@ class StarfieldFX extends BaseFX
 		#end
 		_starfieldType = FieldType;
 		_updateSpeed = speed;
-		
+
 		//	Stars come from the middle of the starfield in 3D mode
 		centerX = Width >> 1;
 		centerY = Height >> 1;
-		
+
 		_clsRect = new Rectangle(0, 0, Width, Height);
 		_clsPoint = new Point();
 		_clsColor = _backgroundColor;
-		
+
 		_stars = new Array<StarObject>();
-		
+
 		for (i in 0...(Quantity))
 		{
 			var star:StarObject = new StarObject();
-			
+
 			star.index = i;
 			star.x = Std.int(Math.random() * Width);
 			star.y = Std.int(Math.random() * Height);
 			star.d = 1;
-			
+
 			if (FieldType == STARFIELD_TYPE_2D)
 			{
 				star.speed = 1 + Std.int(Math.random() * 5);
@@ -112,17 +112,17 @@ class StarfieldFX extends BaseFX
 			{
 				star.speed = Math.random();
 			}
-			
+
 			star.r = Math.random() * Math.PI * 2;
 			star.alpha = 0;
-			
+
 			_stars.push(star);
-			
+
 			#if !flash
 			starDefs.push( { x: 0, y: 0, red: 0, green: 0, blue: 0, alpha: 0 } );
 			#end
 		}
-		
+
 		// Colours array
 		if (FieldType == STARFIELD_TYPE_2D)
 		{
@@ -132,12 +132,12 @@ class StarfieldFX extends BaseFX
 		{
 			_depthColours = FlxGradient.createGradientArray(1, 300, [0xff292929, 0xffffffff]);
 		}
-		
+
 		active = true;
-		
+
 		return sprite;
 	}
-	
+
 	/**
 	 * Change the background color in the format 0xAARRGGBB of the starfield.
 	 * Supports alpha, so if you want a transparent background just pass 0x00 as the color.
@@ -145,7 +145,7 @@ class StarfieldFX extends BaseFX
 	public function setBackgroundColor(BackgroundColor:Int):Void
 	{
 		_clsColor = BackgroundColor;
-		
+
 		#if !flash
 		if (sprite != null)
 		{
@@ -153,10 +153,10 @@ class StarfieldFX extends BaseFX
 		}
 		#end
 	}
-	
+
 	/**
 	 * Change the number of layers (depth) and colors used for each layer of the starfield. Change happens immediately.
-	 * 
+	 *
 	 * @param	Depth			Number of depths (for a 2D starfield the default is 5)
 	 * @param	LowestColor		The color given to the stars furthest away from the camera (i.e. the slowest stars), typically the darker colour
 	 * @param	HighestColor	The color given to the stars cloest to the camera (i.e. the fastest stars), typically the brighter colour
@@ -165,18 +165,18 @@ class StarfieldFX extends BaseFX
 	{
 		// Depth is the same, we just need to update the gradient then
 		_depthColours = FlxGradient.createGradientArray(1, Depth, [LowestColor, HighestColor]);
-		
+
 		// Run through the stars array, making sure the depths are all within range
 		for (star in _stars)
 		{
 			star.speed = 1 + Std.int(Math.random() * Depth);
 		}
 	}
-	
+
 	/**
 	 * Sets the direction and speed of the 2D starfield (doesn't apply to 3D)
 	 * You can combine both X and Y together to make the stars move on a diagnol
-	 * 
+	 *
 	 * @param	ShiftX	How much to shift on the X axis every update. Negative values move towards the left, positiive to the right
 	 * @param	ShiftY	How much to shift on the Y axis every update. Negative values move up, positiive values move down
 	 */
@@ -185,9 +185,9 @@ class StarfieldFX extends BaseFX
 		starXOffset = ShiftX;
 		starYOffset = ShiftY;
 	}
-	
+
 	public var speed(get, set):Int;
-	
+
 	/**
 	 * The current update speed
 	 */
@@ -195,45 +195,45 @@ class StarfieldFX extends BaseFX
 	{
 		return _updateSpeed;
 	}
-	
+
 	/**
 	 * Change the tick interval on which the update runs. By default the starfield updates once every 20ms. Set to zero to disable totally.
 	 */
 	private function set_speed(NewSpeed:Int):Int
 	{
 		_updateSpeed = NewSpeed;
-		
+
 		return NewSpeed;
 	}
-	
+
 	private function update2DStarfield():Void
 	{
 		#if !flash
 		var starSprite:StarSprite = cast(sprite, StarSprite);
 		var starArray:Array<StarDef> = starSprite.starData;
 		#end
-		
+
 		var star:StarObject;
-		
+
 		for (i in 0...(_stars.length))
 		{
 			star = _stars[i];
 			star.x += Math.floor(starXOffset * star.speed);
 			star.y += Math.floor(starYOffset * star.speed);
-			
+
 			#if flash
 			canvas.setPixel32(star.x, star.y, _depthColours[Std.int(star.speed - 1)]);
 			#else
 			var starColor:Int = _depthColours[Std.int(star.speed - 1)];
 			var rgba:RGBA = FlxColorUtil.getRGBA(starColor);
-			
+
 			var starDef:StarDef = starArray[i];
 			starDef.red = rgba.red / 255;
 			starDef.green = rgba.green / 255;
 			starDef.blue = rgba.blue / 255;
 			starDef.alpha = rgba.alpha;
 			#end
-			
+
 			if (star.x > sprite.width)
 			{
 				star.x = 0;
@@ -242,7 +242,7 @@ class StarfieldFX extends BaseFX
 			{
 				star.x = Std.int(sprite.width);
 			}
-			
+
 			if (star.y > sprite.height)
 			{
 				star.y = 0;
@@ -251,43 +251,43 @@ class StarfieldFX extends BaseFX
 			{
 				star.y = Std.int(sprite.height);
 			}
-			
+
 			#if !flash
 			starDef.x = star.x - starSprite.halfWidth;
 			starDef.y = star.y - starSprite.halfHeight;
 			#end
 		}
 	}
-	
+
 	private function update3DStarfield():Void
 	{
 		#if !flash
 		var starSprite:StarSprite = cast(sprite, StarSprite);
 		var starArray:Array<StarDef> = starSprite.starData;
 		#end
-		
+
 		var star:StarObject;
-		
+
 		for (i in 0...(_stars.length))
 		{
 			star = _stars[i];
 			star.d *= 1.1;
 			star.x = Math.floor(centerX + ((Math.cos(star.r) * star.d) * star.speed));
 			star.y = Math.floor(centerY + ((Math.sin(star.r) * star.d) * star.speed));
-			
+
 			star.alpha = star.d * 2;
-			
+
 			if (star.alpha > 255)
 			{
 				star.alpha = 255;
 			}
-			
+
 			#if flash
 			canvas.setPixel32(star.x, star.y, 0xffffffff);
 			#else
 			var rgba:RGBA = FlxColorUtil.getRGBA(FlxColor.WHITE);
 			#end
-			
+
 			#if !flash
 			var starDef:StarDef = starArray[i];
 			starDef.red = rgba.red / 255;
@@ -296,7 +296,7 @@ class StarfieldFX extends BaseFX
 			starDef.alpha = rgba.alpha;
 			#end
 			// canvas.setPixel32(star.x, star.y, FlxColorUtil.getColor32(255, star.alpha, star.alpha, star.alpha));
-			
+
 			if (star.x < 0 || star.x > sprite.width || star.y < 0 || star.y > sprite.height)
 			{
 				star.d = 1;
@@ -305,21 +305,21 @@ class StarfieldFX extends BaseFX
 				star.y = 0;
 				star.speed = Math.random();
 				star.alpha = 0;
-				
+
 				_stars[star.index] = star;
-				
+
 				#if !flash
 				starDef.alpha = 0;
 				#end
 			}
-			
+
 			#if !flash
 			starDef.x = star.x - starSprite.halfWidth;
 			starDef.y = star.y - starSprite.halfHeight;
 			#end
 		}
 	}
-	
+
 	override public function draw():Void
 	{
 		if (FlxG.game.ticks > _tick)
@@ -328,7 +328,7 @@ class StarfieldFX extends BaseFX
 			canvas.lock();
 			canvas.fillRect(_clsRect, _clsColor);
 			#end
-			
+
 			if (_starfieldType == STARFIELD_TYPE_2D)
 			{
 				update2DStarfield();
@@ -337,12 +337,12 @@ class StarfieldFX extends BaseFX
 			{
 				update3DStarfield();
 			}
-			
+
 			#if flash
 			canvas.unlock();
 			sprite.pixels = canvas;
 			#end
-			
+
 			if (_updateSpeed > 0)
 			{
 				_tick = FlxG.game.ticks + _updateSpeed;
@@ -365,32 +365,32 @@ private class StarSprite extends FlxSprite
 	public var bgGreen:Float;
 	public var bgBlue:Float;
 	public var bgAlpha:Float;
-	
+
 	public var halfWidth:Float;
 	public var halfHeight:Float;
-	
+
 	public function new(X:Float = 0, Y:Float = 0, Width:Int = 1, Height:Int = 1, ?bgColor:Int)
 	{
 		super(X, Y);
-		
+
 		bakedRotation = 0;
 		cachedGraphics = FlxG.bitmap.whitePixel;
 		region = new Region(0, 0, 1, 1);
 		region.width = cachedGraphics.bitmap.width;
 		region.height = cachedGraphics.bitmap.height;
 		updateFrameData();
-		
+
 		setBackgroundColor(bgColor);
-		
+
 		width = Width;
 		height = Height;
-		
+
 		halfWidth = 0.5 * Width;
 		halfHeight = 0.5 * Height;
-		
+
 		starData = new Array<StarDef>();
 	}
-	
+
 	public function setBackgroundColor(bgColor:Int):Void
 	{
 		var rgba:RGBA = FlxColorUtil.getRGBA(bgColor);
@@ -399,14 +399,14 @@ private class StarSprite extends FlxSprite
 		bgBlue = rgba.blue / 255;
 		bgAlpha = rgba.alpha;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		starData = null;
 		super.destroy();
 	}
-	
-	override public function draw():Void 
+
+	override public function draw():Void
 	{
 		if (cameras == null)
 		{
@@ -415,21 +415,21 @@ private class StarSprite extends FlxSprite
 		var camera:FlxCamera;
 		var i:Int = 0;
 		var l:Int = cameras.length;
-		
+
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
 		var drawItem:DrawStackItem;
-		
+
 		var radians:Float;
 		var cos:Float;
 		var sin:Float;
-		
+
 		var starRed:Float;
 		var starGreen:Float;
 		var starBlue:Float;
-		
+
 		var starDef:StarDef;
-		
+
 		while (i < l)
 		{
 			camera = cameras[i++];
@@ -437,32 +437,32 @@ private class StarSprite extends FlxSprite
 			{
 				continue;
 			}
-			
+
 			#if !js
 			drawItem = camera.getDrawStackItem(cachedGraphics, true, _blendInt, antialiasing);
 			#else
 			drawItem = camera.getDrawStackItem(cachedGraphics, true);
 			#end
-			
+
 			currDrawData = drawItem.drawData;
 			currIndex = drawItem.position;
-			
+
 			_point.x = (x - (camera.scroll.x * scrollFactor.x) - (offset.x));
 			_point.y = (y - (camera.scroll.y * scrollFactor.y) - (offset.y));
-			
+
 			#if js
 			_point.x = Math.floor(_point.x);
 			_point.y = Math.floor(_point.y);
 			#end
-			
+
 			var csx:Float = 1;
 			var ssy:Float = 0;
 			var ssx:Float = 0;
 			var csy:Float = 1;
 			// yes, 0.5
-			var x1 : Float = 0.5; 
-			var y1 : Float = 0.5; 
-			
+			var x1 : Float = 0.5;
+			var y1 : Float = 0.5;
+
 			if (!simpleRenderSprite ())
 			{
 				if (_angleChanged)
@@ -472,63 +472,63 @@ private class StarSprite extends FlxSprite
 					_cosAngle = Math.cos(radians);
 					_angleChanged = false;
 				}
-				
+
 				csx = _cosAngle * scale.x;
 				ssy = _sinAngle * scale.y;
 				ssx = _sinAngle * scale.x;
 				csy = _cosAngle * scale.y;
 				// yes, zero
-				x1 = 0; 
+				x1 = 0;
 				y1 = 0;
 			}
 
 			_point.x += halfWidth;
 			_point.y += halfHeight;
-			
+
 			// draw background
 			currDrawData[currIndex++] = _point.x;
 			currDrawData[currIndex++] = _point.y;
-			
+
 			currDrawData[currIndex++] = frame.tileID;
-			
+
 			currDrawData[currIndex++] = csx * width;
 			currDrawData[currIndex++] = ssx * width;
 			currDrawData[currIndex++] = -ssy * height;
 			currDrawData[currIndex++] = csy * height;
-			
+
 			#if !js
 			currDrawData[currIndex++] = bgRed;
 			currDrawData[currIndex++] = bgGreen;
 			currDrawData[currIndex++] = bgBlue;
 			#end
-			
+
 			currDrawData[currIndex++] = bgAlpha * alpha;
-			
+
 			// draw stars
 			for (j in 0...(starData.length))
 			{
 				starDef = starData[j];
-				
+
 				var localX:Float = starDef.x;
 				var localY:Float = starDef.y;
-				
+
 				var relativeX:Float = (localX * csx - localY * ssy);
 				var relativeY:Float = (localX * ssx + localY * csy);
-				
+
 				currDrawData[currIndex++] = _point.x + relativeX + x1;
 				currDrawData[currIndex++] = _point.y + relativeY + y1;
-				
+
 				currDrawData[currIndex++] = frame.tileID;
-				
+
 				currDrawData[currIndex++] = csx;
 				currDrawData[currIndex++] = ssx;
 				currDrawData[currIndex++] = -ssy;
 				currDrawData[currIndex++] = csy;
-			
+
 				starRed = starDef.red;
 				starGreen = starDef.green;
 				starBlue = starDef.blue;
-				
+
 			#if !js
 				if (color < 0xffffff)
 				{
@@ -536,15 +536,15 @@ private class StarSprite extends FlxSprite
 					starGreen *= _green;
 					starBlue *= _blue;
 				}
-				
+
 				currDrawData[currIndex++] = starRed;
 				currDrawData[currIndex++] = starGreen;
 				currDrawData[currIndex++] = starBlue;
 			#end
-				
+
 				currDrawData[currIndex++] = alpha * starDef.alpha;
 			}
-			
+
 			drawItem.position = currIndex;
 
 			#if !FLX_NO_DEBUG
@@ -564,7 +564,7 @@ typedef StarDef = {
 }
 #end
 
-private class StarObject 
+private class StarObject
 {
 	public var index:Int;
 	public var x:Int;
@@ -573,6 +573,6 @@ private class StarObject
 	public var speed:Float;
 	public var r:Float;
 	public var alpha:Float;
-	
+
 	public function new() {}
 }

--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -6,8 +6,8 @@ import flash.display.BitmapData;
 import flash.geom.Matrix;
 import flash.geom.Rectangle;
 import flash.utils.ByteArray;
-import flixel.FlxG;
-import flixel.plugin.FlxPlugin;
+import org.flixel.FlxG;
+import org.flixel.plugin.FlxPlugin;
 
 #if flash
 import flash.net.FileReference;
@@ -15,24 +15,24 @@ import flash.net.FileReference;
 
 /**
  * Captures a screen grab of the game and stores it locally, optionally saving as a PNG.
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
  */
 class FlxScreenGrab extends FlxPlugin
 {
 	static public var screenshot:Bitmap;
-	
+
 	static private var _hotkey:String = "";
 	static private var _autoSave:Bool = false;
 	static private var _autoHideMouse:Bool = false;
 	static private var _region:Rectangle;
-	
+
 	/**
 	 * Defines the region of the screen that should be captured. If you need it to be a fixed location then use this.
 	 * If you want to grab the whole SWF size, you don't need to set this as that is the default.
 	 * Remember that if your game is running in a zoom mode > 1 you need to account for this here.
-	 * 
+	 *
 	 * @param	X		The x coordinate (in Flash display space, not Flixel game world)
 	 * @param	Y		The y coordinate (in Flash display space, not Flixel game world)
 	 * @param	Width	The width of the grab region
@@ -42,7 +42,7 @@ class FlxScreenGrab extends FlxPlugin
 	{
 		_region = new Rectangle(X, Y, Width, Height);
 	}
-	
+
 	/**
 	 * Clears a previously defined capture region
 	 */
@@ -50,11 +50,11 @@ class FlxScreenGrab extends FlxPlugin
 	{
 		_region = null;
 	}
-	
+
 	/**
 	 * Specify which key will capture a screen shot. Use the String value of the key in the same way FlxG.keys does (so "F1" for example)
 	 * Optionally save the image to a file immediately. This uses the file systems "Save as" dialog window and pauses your game during the process.
-	 * 
+	 *
 	 * @param	Key			String The key you press to capture the screen (i.e. "F1", "SPACE", etc - see system.input.Keyboard.as source for reference)
 	 * @param	SaveToFile	Boolean If set to true it will immediately encodes the grab to a PNG and open a "Save As" dialog window when the hotkey is pressed
 	 * @param	HideMouse	Boolean If set to true the mouse will be hidden before capture and displayed afterwards when the hotkey is pressed
@@ -65,7 +65,7 @@ class FlxScreenGrab extends FlxPlugin
 		_autoSave = SaveToFile;
 		_autoHideMouse = HideMouse;
 	}
-	
+
 	/**
 	 * Clears a previously defined hotkey
 	 */
@@ -75,10 +75,10 @@ class FlxScreenGrab extends FlxPlugin
 		_autoSave = false;
 		_autoHideMouse = false;
 	}
-	
+
 	/**
 	 * Takes a screen grab immediately of the given region or a previously defined region
-	 * 
+	 *
 	 * @param	CaptureRegion	A Rectangle area to capture. This over-rides that set by "defineCaptureRegion". If neither are set the full SWF size is used.
 	 * @param	SaveToFile		Boolean If set to true it will immediately encode the grab to a PNG and open a "Save As" dialog window
 	 * @param	HideMouse		Boolean If set to true the mouse will be hidden before capture and displayed again afterwards
@@ -87,7 +87,7 @@ class FlxScreenGrab extends FlxPlugin
 	static public function grab(?CaptureRegion:Rectangle, ?SaveToFile:Bool = false, HideMouse:Bool = false):Bitmap
 	{
 		var bounds:Rectangle;
-		
+
 		if (CaptureRegion != null)
 		{
 			bounds = new Rectangle(CaptureRegion.x, CaptureRegion.y, CaptureRegion.width, CaptureRegion.height);
@@ -100,57 +100,57 @@ class FlxScreenGrab extends FlxPlugin
 		{
 			bounds = new Rectangle(0, 0, FlxG.stage.stageWidth, FlxG.stage.stageHeight);
 		}
-		
+
 		var theBitmap:Bitmap = new Bitmap(new BitmapData(Math.floor(bounds.width), Math.floor(bounds.height), true, 0x0));
-		
+
 		var m:Matrix = new Matrix(1, 0, 0, 1, -bounds.x, -bounds.y);
-		
+
 		#if !FLX_NO_MOUSE
 		if (_autoHideMouse || HideMouse)
 		{
 			FlxG.mouse.hide();
 		}
 		#end
-		
+
 		theBitmap.bitmapData.draw(FlxG.stage, m);
-		
+
 		#if !FLX_NO_MOUSE
 		if (_autoHideMouse || HideMouse)
 		{
 			FlxG.mouse.show();
 		}
 		#end
-		
+
 		screenshot = theBitmap;
-		
+
 		if (SaveToFile || _autoSave)
 		{
 			save();
 		}
-		
+
 		return theBitmap;
 	}
-	
+
 	static private function save(Filename:String = ""):Void
 	{
 		if (screenshot.bitmapData == null)
 		{
 			return;
 		}
-		
+
 		if (Filename == "")
 		{
 			var date:String = Date.now().toString();
 			var nameArray:Array<String> = date.split(":");
 			date = nameArray.join("-");
-			
+
 			Filename = "grab-" + date + ".png";
 		}
 		else if (Filename.substr( -4) != ".png")
 		{
 			Filename = Filename + ".png";
 		}
-		
+
 		#if flash
 		var png:ByteArray = PNGEncoder.encode(screenshot.bitmapData);
 		var file:FileReference = new FileReference();
@@ -162,7 +162,7 @@ class FlxScreenGrab extends FlxPlugin
 		f.close();
 		#end
 	}
-	
+
 	override public function update():Void
 	{
 		#if !FLX_NO_KEYBOARD
@@ -175,7 +175,7 @@ class FlxScreenGrab extends FlxPlugin
 		}
 		#end
 	}
-	
+
 	override public function destroy():Void
 	{
 		clearCaptureRegion();

--- a/flixel/addons/plugin/taskManager/AntTaskManager.hx
+++ b/flixel/addons/plugin/taskManager/AntTaskManager.hx
@@ -1,14 +1,14 @@
 package flixel.addons.plugin.taskManager;
 
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.plugin.FlxPlugin;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.plugin.FlxPlugin;
 
 /**
  * The Task Manager is used to perform tasks (call methods) in specified order.
  * Allows you to quickly and easily program any action, such as the appearance of the buttons in the game menus.
  * Task Manager is started automatically when you add at least one task, and stops when all tasks are done.
- * 
+ *
  * @author Anton Karlov
  * @since  08.22.2012
  * @author Zaphod
@@ -20,9 +20,9 @@ class AntTaskManager extends FlxPlugin
 	 * This function will be called when all tasks in the task manager will be completed
 	 */
 	public var onComplete:Void->Void;
-	
+
 	static private var _COUNTER:Int = 0;
-	
+
 	/**
 	 * The list of active tasks
 	 */
@@ -52,41 +52,41 @@ class AntTaskManager extends FlxPlugin
 	 * @default    0
 	 */
 	private var _delay:Float;
-	
+
 	/**
 	 * Constructor
-	 * 
+	 *
 	 * @param	Cycle
 	 * @param	OnComplete
 	 */
 	public function new(Cycle:Bool = false, ?OnComplete:Void->Void)
 	{
 		super();
-		
+
 		ID = _COUNTER;
 		_COUNTER++;
-		
+
 		_taskList = null;
 		_isStarted = false;
 		_isPaused = false;
 		_result = false;
 		_cycle = Cycle;
 		_delay = 0;
-		
+
 		onComplete = OnComplete;
 	}
-	
+
 	override public function destroy():Void
 	{
 		clear();
 		onComplete = null;
 		kill();
 	}
-	
+
 	/**
 	 * Adds a task to the end of queue, the method will be executed while it returns <code>false</code>.
 	 * The task will be completed only when the method will return <code>true</code>. And manager will switch to the next task.
-	 * 
+	 *
 	 * @param	Object				An object to call method-task from
 	 * @param	Function			Method-task to be executed in sequence.
 	 * @param	Arguments	 		An array of arguments that can be passed to the task-method.
@@ -97,12 +97,12 @@ class AntTaskManager extends FlxPlugin
 		push(new AntTask(Object, Function, Arguments, IgnoreCycle, false));
 		start();
 	}
-	
+
 	/**
 	 * Adds a task to the end of queue, the method will be executed only ONCE, after that we go to the next task.
 	 * Добавляет задачу в конец очереди, указанный метод будет выполнен только один раз, после чего будет осуществлен
 	 * переход к следующей задачи не зависимо от того, что вернет метод-задача и вернет ли вообще.
-	 * 
+	 *
 	 * @param	Object	 			An object to call method-task from
 	 * @param	Function	 		Method-task to be executed in sequence.
 	 * @param	Arguments	 		An array of arguments that can be passed to the task-method.
@@ -113,11 +113,11 @@ class AntTaskManager extends FlxPlugin
 		push(new AntTask(Object, Function, Arguments, IgnoreCycle, true));
 		start();
 	}
-	
+
 	/**
 	 * Adds a task to the top of the queue, the method will be executed while it returns <code>false</code>.
 	 * The task will be completed only when the method will return <code>true</code>, and the manager will move to the next task.
-	 * 
+	 *
 	 * @param	Object	 			An object to call method-task from
 	 * @param	Function	 		Method-task to be executed in sequence.
 	 * @param	Arguments	 		An array of arguments that can be passed to the task-method.
@@ -128,10 +128,10 @@ class AntTaskManager extends FlxPlugin
 		unshift(new AntTask(Object, Function, Arguments, IgnoreCycle, false));
 		start();
 	}
-	
+
 	/**
 	 * Adds a task to the top of the queue, the method will be executed only ONCE, after that we go to the next task.
-	 * 
+	 *
 	 * @param	Object	 			An object to call method-task from
 	 * @param	Function	 		Method-task to be executed in sequence.
 	 * @param	Arguments	 		An array of arguments that can be passed to the task-method.
@@ -142,10 +142,10 @@ class AntTaskManager extends FlxPlugin
 		unshift(new AntTask(Object, Function, Arguments, IgnoreCycle, true));
 		start();
 	}
-	
+
 	/**
 	 * Adds a pause between tasks
-	 * 
+	 *
 	 * @param	Delay		 Pause duration
 	 * @param	IgnoreCycle	 If true, the pause will be executed only once per cycle
 	 */
@@ -153,26 +153,26 @@ class AntTaskManager extends FlxPlugin
 	{
 		addTask(this, taskPause, [Delay], IgnoreCycle);
 	}
-	
+
 	/**
 	 * Removes all the tasks from manager and stops it
 	 */
 	public function clear():Void
 	{
 		stop();
-		
+
 		if (_taskList != null)
 		{
 			_taskList.dispose();
 			_taskList = null;
 		}
-		
+
 		_delay = 0;
 	}
-	
+
 	/**
 	 * Move to the next task
-	 * 
+	 *
 	 * @param	IgnoreCycle 	Specifies whether to leave the previous problem in the manager
 	 */
 	public function nextTask(IgnoreCycle:Bool = false):Void
@@ -187,7 +187,7 @@ class AntTaskManager extends FlxPlugin
 			task.dispose();
 		}
 	}
-	
+
 	/**
 	 * Current task processing
 	 */
@@ -196,7 +196,7 @@ class AntTaskManager extends FlxPlugin
 		if (_taskList != null && _isStarted)
 		{
 			_result = Reflect.callMethod(_taskList.obj, _taskList.func, _taskList.args);
-			
+
 			if (_isStarted && (_taskList.instant || _result))
 			{
 				nextTask(_taskList.ignoreCycle);
@@ -205,14 +205,14 @@ class AntTaskManager extends FlxPlugin
 		else
 		{
 			stop();
-			
+
 			if (onComplete != null)
 			{
 				onComplete();
 			}
 		}
 	}
-	
+
 	/**
 	 * Starts the task manager processing
 	 */
@@ -225,7 +225,7 @@ class AntTaskManager extends FlxPlugin
 			_isPaused = false;
 		}
 	}
-	
+
 	/**
 	 * Stops the task manager
 	 */
@@ -237,29 +237,29 @@ class AntTaskManager extends FlxPlugin
 			_isStarted = false;
 		}
 	}
-	
+
 	/**
 	 * Method-task for a pause between tasks
-	 * 
+	 *
 	 * @param	Delay	 Delay
 	 * @return	Returns true when the task is completed
 	 */
 	private function taskPause(Delay:Float):Bool
 	{
 		_delay += FlxG.elapsed;
-		
+
 		if (_delay > Delay)
 		{
 			_delay = 0;
 			return true;
 		}
-		
+
 		return false;
 	}
-	
+
 	/**
 	 * Adds the specified object to the end of the list
-	 * 
+	 *
 	 * @param	Task	The <code>AntTask</code> to be added.
 	 * @return	Returns a pointer to the added <code>AntTask</code>.
 	 */
@@ -269,28 +269,28 @@ class AntTaskManager extends FlxPlugin
 		{
 			return null;
 		}
-		
+
 		if (_taskList == null)
 		{
 			_taskList = Task;
 			return Task;
 		}
-		
+
 		var cur:AntTask = _taskList;
-		
+
 		while (cur.next != null)
 		{
 			cur = cur.next;
 		}
 
 		cur.next = Task;
-		
+
 		return Task;
 	}
-	
+
 	/**
 	 * Adds task to the top of task list
-	 * 
+	 *
 	 * @param	Task	The <code>AntTask</code> to be added.
 	 * @return	Returns a pointer to the added <code>AntTask</code>
 	 */
@@ -300,17 +300,17 @@ class AntTaskManager extends FlxPlugin
 		{
 			return Task;
 		}
-		
+
 		var item:AntTask = _taskList;
 		_taskList = Task;
 		_taskList.next = item;
-		
+
 		return Task;
 	}
-	
+
 	/**
 	 * Removes first task
-	 * 
+	 *
 	 * @return	The task that has been removed
 	 */
 	private function shift():AntTask
@@ -319,19 +319,19 @@ class AntTaskManager extends FlxPlugin
 		{
 			return null;
 		}
-		
+
 		var item:AntTask = _taskList;
 		_taskList = item.next;
 		item.next = null;
-		
+
 		return item;
 	}
-	
+
 	/**
 	 * Sets and gets pause status of this task manager
 	 */
 	public var pause(get, set):Bool;
-	
+
 	private function set_pause(Value:Bool):Bool
 	{
 		if (Value && !_isPaused)
@@ -350,50 +350,50 @@ class AntTaskManager extends FlxPlugin
 			}
 			_isPaused = false;
 		}
-		
+
 		return _isPaused;
 	}
-	
+
 	private function get_pause():Bool
 	{
 		return _isPaused;
 	}
-	
+
 	/**
 	 * Tells if this manager has been started
 	 */
 	public var isStarted(get, never):Bool;
-	
+
 	private function get_isStarted():Bool
 	{
 		return _isStarted;
 	}
-	
+
 	/**
 	 * Number of tasks
 	 */
 	public var length(get, never):Int;
-	
+
 	private function get_length():Int
 	{
 		if (_taskList == null)
 		{
 			return 0;
 		}
-		
+
 		var num:Int = 1;
 		var cur:AntTask = _taskList;
-		
+
 		while (cur.next != null)
 		{
 			cur = cur.next;
 			num++;
 		}
-		
+
 		return num;
 	}
-	
-	override public function toString():String 
+
+	override public function toString():String
 	{
 		var name:String = super.toString() + ID;
 		return name;

--- a/flixel/addons/text/FlxBitmapFont.hx
+++ b/flixel/addons/text/FlxBitmapFont.hx
@@ -3,15 +3,15 @@ package flixel.addons.text;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.FlxCamera;
-import flixel.FlxG;
-import flixel.FlxSprite;
-import flixel.system.layer.DrawStackItem;
-import flixel.system.layer.Region;
-import flixel.util.FlxAngle;
-import flixel.util.FlxColor;
-import flixel.util.loaders.CachedGraphics;
-import flixel.util.loaders.TextureRegion;
+import org.flixel.FlxCamera;
+import org.flixel.FlxG;
+import org.flixel.FlxSprite;
+import org.flixel.system.layer.DrawStackItem;
+import org.flixel.system.layer.Region;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxColor;
+import org.flixel.util.loaders.CachedGraphics;
+import org.flixel.util.loaders.TextureRegion;
 
 /**
  * FlxBitmapFont
@@ -35,7 +35,7 @@ class FlxBitmapFont extends FlxSprite
 	 * Align each line of multi-line text in the center.
 	 */
 	inline static public var ALIGN_CENTER:String = "center";
-	
+
 	/**
 	 * Text Set 1 = !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~
 	 */
@@ -45,7 +45,7 @@ class FlxBitmapFont extends FlxSprite
 	 */
 	inline static public var TEXT_SET2:String = " !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 	/**
-	 * Text Set 3 = ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 
+	 * Text Set 3 = ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
 	 */
 	inline static public var TEXT_SET3:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 ";
 	/**
@@ -57,7 +57,7 @@ class FlxBitmapFont extends FlxSprite
 	 */
 	inline static public var TEXT_SET5:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ.,/() '!?-*:0123456789";
 	/**
-	 * Text Set 6 = ABCDEFGHIJKLMNOPQRSTUVWXYZ!?:;0123456789\"(),-.' 
+	 * Text Set 6 = ABCDEFGHIJKLMNOPQRSTUVWXYZ!?:;0123456789\"(),-.'
 	 */
 	inline static public var TEXT_SET6:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ!?:;0123456789\"(),-.' ";
 	/**
@@ -80,7 +80,7 @@ class FlxBitmapFont extends FlxSprite
 	 * Text Set 11 = ABCDEFGHIJKLMNOPQRSTUVWXYZ.,\"-+!?()':;0123456789
 	 */
 	inline static public var TEXT_SET11:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZ.,\"-+!?()':;0123456789";
-	
+
 	/**
 	 * Alignment of the text when multiLine = true or a fixedWidth is set. Set to FlxBitmapFont.ALIGN_LEFT (default), FlxBitmapFont.ALIGN_RIGHT or FlxBitmapFont.ALIGN_CENTER.
 	 */
@@ -101,7 +101,7 @@ class FlxBitmapFont extends FlxSprite
 	 * Adds vertical spacing between each line of multi-line text, set in pixels. Default is 0.
 	 */
 	public var customSpacingY:Int = 0;
-	
+
 	#if !flash
 	/**
 	 * Offsets for each letter in the sprite (not affected by scale and rotation)
@@ -112,7 +112,7 @@ class FlxBitmapFont extends FlxSprite
 	 */
 	private var _charFrameIDs:Array<Int>;
 	#end
-	
+
 	/**
 	 * Internval values. All set in the constructor. They should not be changed after that point.
 	 */
@@ -128,10 +128,10 @@ class FlxBitmapFont extends FlxSprite
 
     public var characterWidth(default, null):UInt;
     public var characterHeight(default, null):UInt;
-	
+
 	/**
 	 * Loads 'font' and prepares it for use by future calls to .text
-	 * 
+	 *
 	 * @param	Font			The font set graphic class (as defined by your embed)
 	 * @param	CharacterWidth	The width of each character in the font set.
 	 * @param	CharacterHeight	The height of each character in the font set.
@@ -145,13 +145,13 @@ class FlxBitmapFont extends FlxSprite
 	public function new(Font:Dynamic, CharacterWidth:Int, CharacterHeight:Int, Chars:String, CharsPerRow:Int, SpacingX:Int = 0, SpacingY:Int = 0, OffsetX:Int = 0, OffsetY:Int = 0)
 	{
 		super();
-		
+
 		_characterPerRow = CharsPerRow;
 		_charsInFont = Chars;
-		
+
 		// Take a copy of the font for internal use
 		setFontGraphics(FlxG.bitmap.add(Font));
-		
+
         characterWidth = CharacterWidth;
         characterHeight = CharacterHeight;
 
@@ -165,34 +165,34 @@ class FlxBitmapFont extends FlxSprite
 		{
 			_fontRegion = cast(Font, TextureRegion).region.clone();
 		}
-		
+
 		#if flash
 		makeGraphic(1, 1, 0x0, true, "bitmapFont");
 		#else
 		pixels = _fontSet.bitmap;
 		#end
-		
+
 		#if flash
 		updateCharFrameIDs();
 		#end
 	}
-	
+
 	private function setFontGraphics(value:CachedGraphics):Void
 	{
 		if (_fontSet != null && _fontSet != value)
 		{
 			_fontSet.useCount--;
 		}
-		
+
 		if (_fontSet != value && value != null)
 		{
 			value.useCount++;
 		}
 		_fontSet = value;
 	}
-	
+
 	#if !flash
-	override public function updateFrameData():Void 
+	override public function updateFrameData():Void
 	{
 		if (_fontSet != null && _charsInFont != null)
 		{
@@ -200,51 +200,51 @@ class FlxBitmapFont extends FlxSprite
 		}
 	}
 	#end
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		setFontGraphics(null);
 		_grabData = null;
 		_fontRegion = null;
-		
+
 		#if !flash
 		_points = null;
 		_charFrameIDs = null;
 		#end
-		
+
 		super.destroy();
 	}
-	
+
 	private function updateCharFrameIDs():Void
 	{
 		_grabData = new Array();
-		
+
 		//	Now generate our rects for faster copyPixels later on
 		var currentX:Int = _fontRegion.startX;
 		var currentY:Int = _fontRegion.startY;
 		var r:Int = 0;
-		
+
 		var spacingX:Int = _fontRegion.spacingX;
 		var spacingY:Int = _fontRegion.spacingY;
-		
+
 		#if !flash
 		_charFrameIDs = new Array<Int>();
 		var frameID:Int = 0;
 		var rowNumber:Int = 0;
 		var maxPossibleCharsPerRow:Int = Std.int((_fontSet.bitmap.width - _fontRegion.startX) / (_fontRegion.tileWidth + spacingX));
 		#end
-		
+
 		for (c in 0..._charsInFont.length)
 		{
 			// The rect is hooked to the ASCII value of the character
 			_grabData[_charsInFont.charCodeAt(c)] = new Rectangle(currentX, currentY, _fontRegion.tileWidth, _fontRegion.tileHeight);
-			
+
 			#if !flash
 			_charFrameIDs[_charsInFont.charCodeAt(c)] = _fontSet.tilesheet.addTileRect(_grabData[_charsInFont.charCodeAt(c)]);
 			#end
-			
+
 			r++;
-			
+
 			if (r == Std.int(_characterPerRow))
 			{
 				r = 0;
@@ -263,44 +263,44 @@ class FlxBitmapFont extends FlxSprite
 				#end
 			}
 		}
-		
+
 		#if !flash
 		updateTextString(text);
 		#end
 	}
-	
+
 	#if !flash
-	override public function draw():Void 
+	override public function draw():Void
 	{
 		if (cameras == null)
 		{
 			cameras = FlxG.cameras.list;
 		}
-		
+
 		var camera:FlxCamera;
 		var i:Int = 0;
 		var l:Int = cameras.length;
-		
+
 		var j:Int = 0;
 		var textLength:Int = Std.int(_points.length / 3);
 		var currPosInArr:Int;
 		var currTileID:Float;
 		var currTileX:Float;
 		var currTileY:Float;
-		
+
 		var cos:Float;
 		var sin:Float;
 		var relativeX:Float;
 		var relativeY:Float;
-		
+
 		var drawItem:DrawStackItem;
 		var currDrawData:Array<Float>;
 		var currIndex:Int;
-		
+
 		#if js
 		var useAlpha:Bool = (alpha < 1);
 		#end
-		
+
 		while (i < l)
 		{
 			camera = cameras[i++];
@@ -311,15 +311,15 @@ class FlxBitmapFont extends FlxSprite
 			#end
 			currDrawData = drawItem.drawData;
 			currIndex = drawItem.position;
-			
+
 			if (!onScreen(camera) || !camera.visible || !camera.exists)
 			{
 				continue;
 			}
-			
+
 			_point.x = x - (camera.scroll.x * scrollFactor.x) - (offset.x) + origin.x;
 			_point.y = y - (camera.scroll.y * scrollFactor.y) - (offset.y) + origin.y;
-			
+
 			#if js
 			_point.x = Math.floor(_point.x);
 			_point.y = Math.floor(_point.y);
@@ -327,7 +327,7 @@ class FlxBitmapFont extends FlxSprite
 
 			var x1:Float = 0;
 			var y1:Float = 0;
-			
+
 			var csx:Float = 1;
 			var ssy:Float = 0;
 			var ssx:Float = 0;
@@ -342,13 +342,13 @@ class FlxBitmapFont extends FlxSprite
 					_cosAngle = Math.cos(radians);
 					_angleChanged = false;
 				}
-				
+
 				cos = _cosAngle;
 				sin = _sinAngle;
-				
+
 				x1 = (origin.x - _halfWidth);
 				y1 = (origin.y - _halfHeight);
-				
+
 				csx = cos * scale.x;
 				ssy = sin * scale.y;
 				ssx = sin * scale.x;
@@ -364,12 +364,12 @@ class FlxBitmapFont extends FlxSprite
 
 				relativeX = (currTileX * csx - currTileY * ssy);
 				relativeY = (currTileX * ssx + currTileY * csy);
-				
+
 				currDrawData[currIndex++] = (_point.x) + relativeX;
 				currDrawData[currIndex++] = (_point.y) + relativeY;
-				
+
 				currDrawData[currIndex++] = currTileID;
-				
+
 				currDrawData[currIndex++] = csx;
 				currDrawData[currIndex++] = ssx;
 				currDrawData[currIndex++] = -ssy;
@@ -389,35 +389,35 @@ class FlxBitmapFont extends FlxSprite
 					currDrawData[currIndex++] = alpha;
 				}
 				#end
-				
+
 				j++;
 			}
-			
+
 			drawItem.position = currIndex;
 		}
 	}
-	
+
 	override private function get_simpleRender():Bool
-	{ 
+	{
 		return ((angle == 0) && (scale.x == 1) && (scale.y == 1));
 	}
 	#end
-	
+
 	/**
-	 * Set this value to update the text in this sprite. Carriage returns are automatically stripped 
+	 * Set this value to update the text in this sprite. Carriage returns are automatically stripped
 	 * out if multiLine is false. Text is converted to upper case if autoUpperCase is true.
-	 */ 
+	 */
 	public var text(get, set):String;
-	
+
 	private function get_text():String
 	{
 		return _text;
 	}
-	
+
 	private function set_text(NewText:String):String
 	{
 		var newText:String;
-		
+
 		if (autoUpperCase)
 		{
 			newText = NewText.toUpperCase();
@@ -426,27 +426,27 @@ class FlxBitmapFont extends FlxSprite
 		{
 			newText = NewText;
 		}
-		
+
 		// Smart update: Only change the bitmap data if the string has changed
 		if (newText != _text)
 		{
 			updateTextString(newText);
 		}
-		
+
 		return _text;
 	}
-	
+
 	private function updateTextString(NewText:String):Void
 	{
 		_text = NewText;
 		_text = removeUnsupportedCharacters(multiLine);
 		buildBitmapFontText();
 	}
-	
+
 	/**
 	 * If you need this FlxSprite to have a fixed width and custom alignment you can set the width here.<br>
 	 * If text is wider than the width specified it will be cropped off.
-	 * 
+	 *
 	 * @param	Width			Width in pixels of this FlxBitmapFont. Set to zero to disable and re-enable automatic resizing.
 	 * @param	LineAlignment	Align the text within this width. Set to FlxBitmapFont.ALIGN_LEFT (default), FlxBitmapFont.ALIGN_RIGHT or FlxBitmapFont.ALIGN_CENTER.
 	 */
@@ -455,10 +455,10 @@ class FlxBitmapFont extends FlxSprite
 		_fixedWidth = Width;
 		align = LineAlignment;
 	}
-	
+
 	/**
 	 * A helper function that quickly sets lots of variables at once, and then updates the text.
-	 * 
+	 *
 	 * @param	Text				The text of this sprite
 	 * @param	MultiLines			Set to true if you want to support carriage-returns in the text and create a multi-line sprite instead of a single line (default is false).
 	 * @param	CharacterSpacing	To add horizontal spacing between each character specify the amount in pixels (default 0).
@@ -472,7 +472,7 @@ class FlxBitmapFont extends FlxSprite
 		customSpacingY = LineSpacing;
 		align = LineAlignment;
 		multiLine = MultiLines;
-		
+
 		if (AllowLowerCase)
 		{
 			autoUpperCase = false;
@@ -481,13 +481,13 @@ class FlxBitmapFont extends FlxSprite
 		{
 			autoUpperCase = true;
 		}
-		
+
 		if (Text.length > 0)
 		{
 			text = Text;
 		}
 	}
-	
+
 	/**
 	 * Updates the BitmapData of the Sprite with the text
 	 */
@@ -496,7 +496,7 @@ class FlxBitmapFont extends FlxSprite
 		var temp:BitmapData;
 		var cx:Int = 0;
 		var cy:Int = 0;
-		
+
 		#if !flash
 		if (_points == null)
 		{
@@ -507,16 +507,16 @@ class FlxBitmapFont extends FlxSprite
 			_points.splice(0, _points.length);
 		}
 		#end
-		
+
 		if (multiLine)
 		{
 			var lines:Array<String> = _text.split("\n");
 			_textHeight = (lines.length * (_fontRegion.tileHeight + customSpacingY)) - customSpacingY;
-			
+
 			if (_fixedWidth > 0)
 			{
 				_textWidth = _fixedWidth;
-				
+
 				#if flash
 				temp = new BitmapData(_fixedWidth, _textHeight, true, 0xf);
 				#end
@@ -524,12 +524,12 @@ class FlxBitmapFont extends FlxSprite
 			else
 			{
 				_textWidth = getLongestLine() * (_fontRegion.tileWidth + customSpacingX);
-				
+
 				#if flash
 				temp = new BitmapData(_textWidth, _textHeight, true, 0xf);
 				#end
 			}
-			
+
 			// Loop through each line of text
 			for (i in 0...lines.length)
 			{
@@ -544,31 +544,31 @@ class FlxBitmapFont extends FlxSprite
 						cx = Math.floor((_textWidth / 2) - ((lines[i].length * (_fontRegion.tileWidth + customSpacingX)) / 2));
 						cx += Math.floor(customSpacingX / 2);
 				}
-				
+
 				// Sanity checks
 				if (cx < 0)
 				{
 					cx = 0;
 				}
-				
+
 				#if flash
 				pasteLine(temp, lines[i], cx, cy, customSpacingX);
 				#else
 				origin.set(_textWidth * 0.5, _textHeight * 0.5);
 				pasteLine(lines[i], cx, cy, customSpacingX);
 				#end
-				
+
 				cy += _fontRegion.tileHeight + customSpacingY;
 			}
 		}
 		else
 		{
 			_textHeight = _fontRegion.tileHeight;
-			
+
 			if (_fixedWidth > 0)
 			{
 				_textWidth = _fixedWidth;
-				
+
 				#if flash
 				temp = new BitmapData(_textWidth, _textHeight, true, 0xf);
 				#end
@@ -576,12 +576,12 @@ class FlxBitmapFont extends FlxSprite
 			else
 			{
 				_textWidth = _text.length * (_fontRegion.tileWidth + customSpacingX);
-				
+
 				#if flash
 				temp = new BitmapData(_textWidth, _textHeight, true, 0xf);
 				#end
 			}
-			
+
 			switch (align)
 			{
 				case ALIGN_LEFT:
@@ -592,7 +592,7 @@ class FlxBitmapFont extends FlxSprite
 					cx = Math.floor((_textWidth / 2) - ((_text.length * (_fontRegion.tileWidth + customSpacingX)) / 2));
 					cx += Math.floor(customSpacingX / 2);
 			}
-			
+
 			#if flash
 			pasteLine(temp, _text, cx, 0, customSpacingX);
 			#else
@@ -600,7 +600,7 @@ class FlxBitmapFont extends FlxSprite
 			pasteLine(_text, cx, 0, customSpacingX);
 			#end
 		}
-		
+
 		#if flash
 		var key:String = cachedGraphics.key;
 		FlxG.bitmap.remove(key);
@@ -614,10 +614,10 @@ class FlxBitmapFont extends FlxSprite
 		centerOffsets();
 		#end
 	}
-	
+
 	/**
 	 * Returns a single character from the font set as an FlxSprite.
-	 * 
+	 *
 	 * @param	Char	The character you wish to have returned.
 	 * @return	A <code>FlxSprite</code> containing a single character from the font set.
 	 */
@@ -630,34 +630,34 @@ class FlxBitmapFont extends FlxSprite
 		{
 			temp.copyPixels(_fontSet.bitmap, _grabData[Char.charCodeAt(0)], new Point(0, 0));
 		}
-		
+
 		output.pixels = temp;
-		
+
 		return output;
 	}
-	
+
 	/**
 	 * Returns a single character from the font set as bitmapData
-	 * 
+	 *
 	 * @param	Char	The character you wish to have returned.
 	 * @return	<code>bitmapData</code> containing a single character from the font set.
 	 */
 	public function getCharacterAsBitmapData(Char:String):BitmapData
 	{
 		var temp:BitmapData = new BitmapData(_fontRegion.tileWidth, _fontRegion.tileHeight, true, FlxColor.TRANSPARENT);
-		
+
 		if (_grabData[Char.charCodeAt(0)] != null)
 		{
 			temp.copyPixels(_fontSet.bitmap, _grabData[Char.charCodeAt(0)], new Point(0, 0));
 		}
-		
+
 		return temp;
 	}
-	
+
 	/**
 	 * Internal function that takes a single line of text (2nd parameter) and pastes it into the BitmapData at the given coordinates.
 	 * Used by getLine and getMultiLine
-	 * 
+	 *
 	 * @param	Output			The BitmapData that the text will be drawn onto
 	 * @param	Line			The single line of text to paste
 	 * @param	X				The x coordinate
@@ -689,9 +689,9 @@ class FlxBitmapFont extends FlxSprite
 					_points.push(X - origin.x);
 					_points.push(Y - origin.y);
 					#end
-					
+
 					X += _fontRegion.tileWidth + CustomSpacingX;
-					
+
 					#if flash
 					if (Math.floor(X) > Output.width)
 					#else
@@ -704,20 +704,20 @@ class FlxBitmapFont extends FlxSprite
 			}
 		}
 	}
-	
+
 	/**
 	 * Works out the longest line of text in _text and returns its length
-	 * 
+	 *
 	 * @return	A value
 	 */
 	private function getLongestLine():Int
 	{
 		var longestLine:Int = 0;
-		
+
 		if (_text.length > 0)
 		{
 			var lines:Array<String> = _text.split("\n");
-			
+
 			for (i in 0...lines.length)
 			{
 				if (lines[i].length > Math.floor(longestLine))
@@ -726,20 +726,20 @@ class FlxBitmapFont extends FlxSprite
 				}
 			}
 		}
-		
+
 		return longestLine;
 	}
-	
+
 	/**
 	 * Internal helper function that removes all unsupported characters from the _text String, leaving only characters contained in the font set.
-	 * 
+	 *
 	 * @param	StripCR		Should it strip carriage returns as well? (default = true)
 	 * @return	A clean version of the string
 	 */
 	private function removeUnsupportedCharacters(StripCR:Bool = true):String
 	{
 		var newString:String = "";
-		
+
 		for (c in 0...(_text.length))
 		{
 			if (_grabData[_text.charCodeAt(c)] != null || _text.charCodeAt(c) == 32 || (StripCR == true && _text.charAt(c) == "\n"))
@@ -747,7 +747,7 @@ class FlxBitmapFont extends FlxSprite
 				newString = newString + _text.charAt(c);
 			}
 		}
-		
+
 		return newString;
 	}
 }

--- a/flixel/addons/tile/FlxRayCastTilemap.hx
+++ b/flixel/addons/tile/FlxRayCastTilemap.hx
@@ -1,7 +1,7 @@
 package flixel.addons.tile;
 
-import flixel.tile.FlxTilemap;
-import flixel.util.FlxPoint;
+import org.flixel.tile.FlxTilemap;
+import org.flixel.util.FlxPoint;
 
 /**
  * @author greglieberman
@@ -34,72 +34,72 @@ class FlxRayCastTilemap extends FlxTilemap
 	{
 		// Current x, y, in tiles
 		var cx:Float;
-		var cy:Float;	
+		var cy:Float;
 		// Starting tile cell bounds, in pixels
 		var cbx:Float;
-		var cby:Float;   
+		var cby:Float;
 		// Maximum time the ray has traveled so far (not distance!)
 		var tMaxX:Float;
-		var tMaxY:Float;   
+		var tMaxY:Float;
 		// The time that the ray needs to travel to cross a single tile (not distance!)
 		var tDeltaX:Float = 0;
-		var tDeltaY:Float = 0;  
+		var tDeltaY:Float = 0;
 		// Step direction, either 1 or -1
 		var stepX:Float;
-		var stepY:Float;   
+		var stepY:Float;
 		// Bounds of the tileMap where the ray would exit
 		var outX:Float;
-		var outY:Float;   
-		var hitTile:Bool = false;  
+		var outY:Float;
+		var hitTile:Bool = false;
 		var tResult:Float = 0;
-  
+
 		if (Start == null)
 		{
 			return false;
 		}
-  
+
 		if (Result == null)
 		{
 			Result = new FlxPoint();
 		}
-		
+
 		if (Direction == null || (Direction.x == 0 && Direction.y == 0))
 		{
 			// No direction, no ray
 			Result.x = Start.x;
 			Result.y = Start.y;
-			
+
 			return false;
 		}
-		
+
 		// Find the tile at the start position of the ray
 		cx = coordsToTileX(Start.x);
 		cy = coordsToTileY(Start.y);
-		
+
 		if (!inTileRange(cx, cy))
 		{
 			// Outside of the tilemap
 			Result.x = Start.x;
 			Result.y = Start.y;
-			
-			return false;   
+
+			return false;
 		}
-		
+
 		if (getTile(Std.int(cx), Std.int(cy)) > 0)
 		{
 			// start point is inside a block
 			Result.x = Start.x;
 			Result.y = Start.y;
-			
+
 			return true;
 		}
-		
+
 		if (MaxTilesToCheck == -1)
 		{
 			// This number is large enough to guarantee that the ray will pass through the entire tile map
 			MaxTilesToCheck = widthInTiles * heightInTiles;
 		}
-		
+
 		// Determine step direction, and initial starting block
 		if (Direction.x > 0)
 		{
@@ -113,7 +113,7 @@ class FlxRayCastTilemap extends FlxTilemap
 			outX = -1;
 			cbx = x + cx * _tileWidth;
 		}
-		
+
 		if (Direction.y > 0)
 		{
 			stepY = 1;
@@ -126,7 +126,7 @@ class FlxRayCastTilemap extends FlxTilemap
 			outY = -1;
 			cby = y + cy * _tileHeight;
 		}
-		
+
 		// Determine tMaxes and deltas
 		if (Direction.x != 0)
 		{
@@ -137,7 +137,7 @@ class FlxRayCastTilemap extends FlxTilemap
 		{
 			tMaxX = 1000000;
 		}
-		
+
 		if (Direction.y != 0)
 		{
 			tMaxY = (cby - Start.y) / Direction.y;
@@ -147,8 +147,8 @@ class FlxRayCastTilemap extends FlxTilemap
 		{
 			tMaxY = 1000000;
 		}
-		
-		// Step through each block  
+
+		// Step through each block
 		for (tileCount in 0...MaxTilesToCheck)
 		{
 			if (tMaxX < tMaxY)
@@ -159,69 +159,69 @@ class FlxRayCastTilemap extends FlxTilemap
 					hitTile = true;
 					break;
 				}
-				
+
 				if (cx == outX)
 				{
 					hitTile = false;
 					break;
 				}
-				
+
 				tMaxX = tMaxX + tDeltaX;
 			}
 			else
 			{
 				cy = cy + stepY;
-				
+
 				if (getTile(Std.int(cx), Std.int(cy)) > 0)
 				{
 					hitTile = true;
 					break;
 				}
-				
+
 				if (cy == outY)
 				{
 					hitTile = false;
 					break;
 				}
-				
+
 				tMaxY = tMaxY + tDeltaY;
 			}
 		}
-		
+
 		// Result time
 		tResult = (tMaxX < tMaxY) ? tMaxX : tMaxY;
-		
+
 		// Store the result
 		Result.x = Start.x + (Direction.x * tResult);
 		Result.y = Start.y + (Direction.y * tResult);
-		
+
 		if (ResultInTiles != null)
 		{
 			ResultInTiles.x = cx;
 			ResultInTiles.y = cy;
 		}
-		
+
 		return hitTile;
 	}
-   
+
 	public function inTileRange(TileX:Float, TileY:Float):Bool
 	{
 		return (TileX >= 0 && TileX < widthInTiles && TileY >= 0 && TileY < heightInTiles);
 	}
-   
+
 	public function tileAt(CoordX:Float, CoordY:Float):Int
 	{
 		return getTile(Std.int((CoordX - x) / _tileWidth), Std.int((CoordY - y) / _tileHeight));
 	}
-  
+
 	public function tileIndexAt(CoordX:Float, CoordY:Float):Int
 	{
 		var X:Int = Std.int((CoordX - x) / _tileWidth);
 		var Y:Int = Std.int((CoordY - y) / _tileHeight);
-		
+
 		return Y * widthInTiles + X;
 	}
- 
+
 	/**
 	* @param X in tiles
 	* @param Y in tiles
@@ -229,9 +229,9 @@ class FlxRayCastTilemap extends FlxTilemap
 	*/
 	public function getTileIndex(X:Int, Y:Int):Int
 	{
-		return Y * widthInTiles + X;   
+		return Y * widthInTiles + X;
 	}
-   
+
 	public function coordsToTileX(CoordX:Float):Float
 	{
 	return Std.int((CoordX - x) / _tileWidth);

--- a/flixel/addons/tile/FlxTileSpecial.hx
+++ b/flixel/addons/tile/FlxTileSpecial.hx
@@ -4,41 +4,41 @@ import flash.display.BitmapData;
 import flash.geom.Matrix;
 import flash.geom.Point;
 import flash.geom.Rectangle;
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.util.FlxAngle;
-import flixel.util.FlxColor;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxColor;
 
 class FlxTileSpecial extends FlxBasic
 {
 	public static inline var ROTATE_0 = 0;
 	public static inline var ROTATE_90 = 1;
 	public static inline var ROTATE_270 = 2;
-	
+
 	/**
 	 * The id of this tile in the tileset
 	 */
 	public var tileID:Int;
-	
+
 	public var flipHorizontally:Bool = false;
 	public var flipVertically:Bool = false;
-	
+
 	public var rotate:Int;
-	
+
 	private var _tmp_flipH:Bool;
 	private var _tmp_flipV:Bool;
 	private var _tmp_rot:Int;
-	
+
 	#if flash
 	private var _normalFrame:BitmapData;
 	private var _flippedFrame:BitmapData;
 	private var _point:Point;
-	
+
 	public var tileRect:Rectangle;
 	#end
-	
+
 	private var _matrix:Matrix;
-	
+
 	// Animation stuff
 	private var _animation:FlxTileAnimation;
 	private var _currFrame:Int = 0;
@@ -46,13 +46,13 @@ class FlxTileSpecial extends FlxBasic
 	private var _currTileId:Int;
 	private var _currAnimParam:AnimParams;
 	private var _frameTimer:Float = 0.0;
-	
+
 	#if flash
 	private var _animRects:Array<Rectangle>;
 	public var dirty:Bool = true;
 	#end
-	
-	public function new(TilesetId:Int, FlipHorizontal:Bool, FlipVertical:Bool, Rotate:Int) 
+
+	public function new(TilesetId:Int, FlipHorizontal:Bool, FlipVertical:Bool, Rotate:Int)
 	{
 		super();
 		this.tileID = TilesetId;
@@ -60,42 +60,42 @@ class FlxTileSpecial extends FlxBasic
 		this.flipHorizontally = FlipHorizontal;
 		this.flipVertically = FlipVertical;
 		this.rotate = Rotate;
-		
+
 		#if flash
 		this._normalFrame = null;
 		this._flippedFrame = null;
 		this._point = new Point(0, 0);
-		
+
 		_animRects = null;
 		tileRect = new Rectangle();
 		#end
-		
+
 		this._matrix = new Matrix();
 		this._animation = null;
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		super.destroy();
-		
+
 		#if flash
 		if (_normalFrame != null)
 		{
 			_normalFrame.dispose();
 		}
 		_normalFrame = null;
-		
+
 		if (_flippedFrame != null)
 		{
 			_flippedFrame.dispose();
 		}
 		_flippedFrame = null;
-		
+
 		_point = null;
 		_animRects = null;
 		tileRect = null;
 		#end
-		
+
 		if (_animation != null)
 		{
 			_animation.destroy();
@@ -104,22 +104,22 @@ class FlxTileSpecial extends FlxBasic
 		_currAnimParam = null;
 		_matrix = null;
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		super.update();
 		#if flash
 		dirty = false;
 		#end
 		// Modified from updateAnimation() in FlxSprite
-		if (_animation != null && _animation.delay > 0) 
+		if (_animation != null && _animation.delay > 0)
 		{
 			_frameTimer += FlxG.elapsed;
-			if (_frameTimer > _animation.delay) 
+			if (_frameTimer > _animation.delay)
 			{
 				_lastFrame = _currFrame;
 			}
-			while (_frameTimer > _animation.delay) 
+			while (_frameTimer > _animation.delay)
 			{
 				_frameTimer = _frameTimer - _animation.delay;
 				if (_currFrame >= _animation.frames.length - 1)
@@ -132,143 +132,143 @@ class FlxTileSpecial extends FlxBasic
 				}
 			}
 			_currTileId = _animation.frames[_currFrame];
-			if (_animation.framesData != null) 
+			if (_animation.framesData != null)
 			{
 				_currAnimParam = _animation.framesData[_currFrame];
 			}
-			
+
 			#if flash
 			dirty = !(_currFrame == _lastFrame);
 			#end
 		}
 	}
-	
-	public inline function isSpecial():Bool 
+
+	public inline function isSpecial():Bool
 	{
 		return (isFlipped() || hasAnimation());
 	}
-	
-	public inline function isFlipped():Bool 
+
+	public inline function isFlipped():Bool
 	{
 		return ((flipHorizontally || flipVertically) || rotate != ROTATE_0);
 	}
-	
-	public inline function hasAnimation():Bool 
+
+	public inline function hasAnimation():Bool
 	{
 		return (_animation != null);
 	}
-	
+
 	#if flash
-	public function getBitmapData(width:Int, height:Int, rect:Rectangle, bitmap:BitmapData):BitmapData 
+	public function getBitmapData(width:Int, height:Int, rect:Rectangle, bitmap:BitmapData):BitmapData
 	{
 		if (_normalFrame == null)
 		{
 			_normalFrame = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
 		}
-		
+
 		var generateFlipped:Bool = (_flippedFrame == null);
 		if (generateFlipped)
 		{
 			_flippedFrame = new BitmapData(width, height, true, FlxColor.TRANSPARENT);
 		}
 
-		if (generateFlipped || dirty) 
+		if (generateFlipped || dirty)
 		{
 			tileRect.width = width;
 			tileRect.height = height;
-			
+
 			_normalFrame.fillRect(tileRect, FlxColor.TRANSPARENT);
 			_flippedFrame.fillRect(tileRect, FlxColor.TRANSPARENT);
-			
-			if (_animRects != null && _animRects[_currFrame] != null) 
+
+			if (_animRects != null && _animRects[_currFrame] != null)
 			{
 				rect = _animRects[_currFrame];
 			}
-			
+
 			_normalFrame.copyPixels(bitmap, rect, _point, null, null, true);
 			_flippedFrame.draw(_normalFrame, getMatrix(width, height));
 			dirty = true;
 		}
-		
+
 		return _flippedFrame;
 	}
-	
+
 	/**
 	 * Set the animation rectangles for flash
 	 * @param	rects	An array with rectangles
 	 */
-	public function setAnimationRects(rects:Array<Rectangle>):Void 
+	public function setAnimationRects(rects:Array<Rectangle>):Void
 	{
 		this._animRects = rects;
 	}
 	#end
-	
+
 	/**
 	 * Add an animation to this special tile
 	 * @param	tiles		An array with the tilesetID of each frame
 	 * @param	frameRate	The speed of the animation in frames per second (Default: 30)
 	 */
-	public function addAnimation(tiles:Array<Int>, frameRate:Float = 30, ?framesData:Array<AnimParams>):Void 
+	public function addAnimation(tiles:Array<Int>, frameRate:Float = 30, ?framesData:Array<AnimParams>):Void
 	{
 		_animation = new FlxTileAnimation("tileAnim", tiles, frameRate, true, framesData);
 	}
-	
+
 	/**
 	 * Returns the current tileID of this tile in the tileset
 	 * @return The current tileID
 	 */
-	public function getCurrentTileId():Int 
+	public function getCurrentTileId():Int
 	{
 		return _currTileId;
 	}
-	
+
 	/**
 	 * Get the animation tiles id if any
 	 * @return	An array of ids or null
 	 */
-	public function getAnimationTilesId():Array<Int> 
+	public function getAnimationTilesId():Array<Int>
 	{
-		if (_animation != null) 
+		if (_animation != null)
 		{
 			return _animation.frames;
 		}
-		
+
 		return null;
 	}
-	
+
 	/**
 	 * Calculates and return the matrix
 	 * @param	width	the tile width
 	 * @param	height	the tile height
 	 * @return	The matrix calculated
 	 */
-	public function getMatrix(width:Int, height:Int):Matrix 
+	public function getMatrix(width:Int, height:Int):Matrix
 	{
 		_tmp_flipH = flipHorizontally;
 		_tmp_flipV = flipVertically;
 		_tmp_rot = rotate;
-		
+
 		if (_currAnimParam != null) {
 			_tmp_flipH = _currAnimParam.flipHorizontal;
 			_tmp_flipV = _currAnimParam.flipVertical;
 			_tmp_rot = _currAnimParam.rotate;
 		}
-		
+
 		_matrix.identity();
-		if (_tmp_flipH) 
+		if (_tmp_flipH)
 		{
 			_matrix.scale( -1, 1);
 			_matrix.translate(width, 0);
 		}
-		if (_tmp_flipV) 
+		if (_tmp_flipV)
 		{
 			_matrix.scale(1, -1);
 			_matrix.translate(0, height);
 		}
-		
-		if (_tmp_rot != FlxTileSpecial.ROTATE_0) 
+
+		if (_tmp_rot != FlxTileSpecial.ROTATE_0)
 		{
-			switch(_tmp_rot) 
+			switch(_tmp_rot)
 			{
 				case FlxTileSpecial.ROTATE_90:
 					_matrix.rotate(90 * FlxAngle.TO_RAD);
@@ -279,13 +279,13 @@ class FlxTileSpecial extends FlxBasic
 					_matrix.translate(0, height);
 			}
 		}
-		
+
 		return _matrix;
 	}
 }
 
 
-typedef AnimParams = 
+typedef AnimParams =
 {
 	var flipHorizontal:Bool;
 	var flipVertical:Bool;

--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -6,15 +6,15 @@ import flash.geom.Point;
 import flash.geom.Rectangle;
 import flixel.addons.tile.FlxTilemapExt;
 import flixel.addons.tile.FlxTileSpecial;
-import flixel.FlxCamera;
-import flixel.FlxG;
-import flixel.FlxObject;
-import flixel.system.layer.DrawStackItem;
-import flixel.tile.FlxTile;
-import flixel.tile.FlxTilemap;
-import flixel.tile.FlxTilemapBuffer;
-import flixel.util.FlxMath;
-import flixel.util.FlxPoint;
+import org.flixel.FlxCamera;
+import org.flixel.FlxG;
+import org.flixel.FlxObject;
+import org.flixel.system.layer.DrawStackItem;
+import org.flixel.tile.FlxTile;
+import org.flixel.tile.FlxTilemap;
+import org.flixel.tile.FlxTilemapBuffer;
+import org.flixel.util.FlxMath;
+import org.flixel.util.FlxPoint;
 
 
 /**
@@ -32,33 +32,33 @@ class FlxTilemapExt extends FlxTilemap
 	inline static public var SLOPE_FLOOR_RIGHT:Int = 1;
 	inline static public var SLOPE_CEIL_LEFT:Int = 2;
 	inline static public var SLOPE_CEIL_RIGHT:Int = 3;
-	
+
 	// Slope related variables
 	private var _snapping:Int = 2;
 	private var _slopePoint:FlxPoint;
 	private var _objPoint:FlxPoint;
-	
+
 	private var _slopeFloorLeft:Array<Int>;
 	private var _slopeFloorRight:Array<Int>;
 	private var _slopeCeilLeft:Array<Int>;
 	private var _slopeCeilRight:Array<Int>;
-	
+
 	// Animated and flipped tiles related variables
 	private var MATRIX:Matrix;
 	private var _specialTiles:Array<FlxTileSpecial>;
-	
+
 	// Alpha stuff
 	#if flash
 	private var _flashAlpha:BitmapData;
 	private var _flashAlphaPoint:Point;
 	#end
 	public var alpha(default, set):Float = 1.0;
-	
-	public function set_alpha(alpha:Float):Float 
+
+	public function set_alpha(alpha:Float):Float
 	{
 		this.alpha = alpha;
 		#if flash
-		if (_tileWidth == 0 || _tileHeight == 0) 
+		if (_tileWidth == 0 || _tileHeight == 0)
 		{
 			throw "You can't set the alpha of the tilemap before loading it";
 		}
@@ -66,42 +66,42 @@ class FlxTilemapExt extends FlxTilemap
 		_flashAlpha = new BitmapData(_tileWidth, _tileHeight, true, alphaCol);
 		_flashAlphaPoint = new Point(0, 0);
 		#end
-		
+
 		return alpha;
 	}
-	
+
 	public function new()
 	{
 		super();
-		
+
 		_slopePoint = new FlxPoint();
 		_objPoint = new FlxPoint();
-		
+
 		_slopeFloorLeft = new Array<Int>();
 		_slopeFloorRight = new Array<Int>();
 		_slopeCeilLeft = new Array<Int>();
 		_slopeCeilRight = new Array<Int>();
-		
+
 		// Flipped/rotated tiles variables
 		_specialTiles = null;
 		MATRIX = new Matrix();
 	}
-	
-	override public function destroy():Void 
+
+	override public function destroy():Void
 	{
 		_slopePoint = null;
 		_objPoint = null;
-		
+
 		_slopeFloorLeft = null;
 		_slopeFloorRight = null;
 		_slopeCeilLeft = null;
 		_slopeCeilRight = null;
-		
+
 		super.destroy();
-		
-		if (_specialTiles != null) 
+
+		if (_specialTiles != null)
 		{
-			for (t in _specialTiles) 
+			for (t in _specialTiles)
 			{
 				if (t != null)
 				{
@@ -111,7 +111,7 @@ class FlxTilemapExt extends FlxTilemap
 		}
 		_specialTiles = null;
 		MATRIX = null;
-		
+
 		#if flash
 		if (_flashAlpha != null)
 		{
@@ -121,41 +121,41 @@ class FlxTilemapExt extends FlxTilemap
 		_flashAlphaPoint = null;
 		#end
 	}
-	
-	override public function update():Void 
+
+	override public function update():Void
 	{
 		super.update();
-		if (_specialTiles != null && _specialTiles.length > 0) 
+		if (_specialTiles != null && _specialTiles.length > 0)
 		{
-			for (t in _specialTiles) 
+			for (t in _specialTiles)
 			{
-				if (t != null && t.hasAnimation()) 
+				if (t != null && t.hasAnimation())
 				{
 					t.update();
 				}
 			}
 		}
 	}
-	
+
 	/**
 	 * THIS IS A COPY FROM <code>FlxTilemap</code> BUT IT DEALS WITH FLIPPED AND ROTATED TILES
 	 * Internal function that actually renders the tilemap to the tilemap buffer.  Called by draw().
 	 * @param	Buffer		The <code>FlxTilemapBuffer</code> you are rendering to.
 	 * @param	Camera		The related <code>FlxCamera</code>, mainly for scroll values.
 	 */
-	override private function drawTilemap(Buffer:FlxTilemapBuffer, Camera:FlxCamera):Void 
+	override private function drawTilemap(Buffer:FlxTilemapBuffer, Camera:FlxCamera):Void
 	{
 		#if flash
 		Buffer.fill();
 		#else
-		
+
 		_helperPoint.x = x - Camera.scroll.x * scrollFactor.x; //copied from getScreenXY()
 		_helperPoint.y = y - Camera.scroll.y * scrollFactor.y;
-		
+
 		var tileID:Int;
 		var drawX:Float;
 		var drawY:Float;
-		
+
 		#if !js
 		var drawItem:DrawStackItem = Camera.getDrawStackItem(cachedGraphics, false, 0);
 		#else
@@ -164,7 +164,7 @@ class FlxTilemapExt extends FlxTilemap
 		var currDrawData:Array<Float> = drawItem.drawData;
 		var currIndex:Int = drawItem.position;
 		#end
-		
+
 		// Copy tile images into the tile buffer
 		_point.x = (Camera.scroll.x * scrollFactor.x) - x; //modified from getScreenXY()
 		_point.y = (Camera.scroll.y * scrollFactor.y) - y;
@@ -172,7 +172,7 @@ class FlxTilemapExt extends FlxTilemap
 		var screenYInTiles:Int = Math.floor(_point.y / _tileHeight);
 		var screenRows:Int = Buffer.rows;
 		var screenColumns:Int = Buffer.columns;
-		
+
 		// Bound the upper left corner
 		if (screenXInTiles < 0)
 		{
@@ -190,7 +190,7 @@ class FlxTilemapExt extends FlxTilemap
 		{
 			screenYInTiles = heightInTiles - screenRows;
 		}
-		
+
 		var rowIndex:Int = screenYInTiles * widthInTiles + screenXInTiles;
 		_flashPoint.y = 0;
 		var row:Int = 0;
@@ -201,70 +201,70 @@ class FlxTilemapExt extends FlxTilemap
 
 		#if !FLX_NO_DEBUG
 		var debugTile:BitmapData;
-		#end 
-		
+		#end
+
 		var isSpecial = false;
-		
+
 		while (row < screenRows)
 		{
 			columnIndex = rowIndex;
 			column = 0;
 			_flashPoint.x = 0;
-			
+
 			while (column < screenColumns)
 			{
 				#if flash
 				_flashRect = _rects[columnIndex];
-				
+
 				if (_flashRect != null)
 				{
-					if (_specialTiles != null && _specialTiles[columnIndex] != null) 
+					if (_specialTiles != null && _specialTiles[columnIndex] != null)
 					{
 						special = _specialTiles[columnIndex];
 						isSpecial = special.isSpecial();
-						if (isSpecial) 
+						if (isSpecial)
 						{
 							Buffer.pixels.copyPixels(
 								special.getBitmapData(_tileWidth, _tileHeight, _flashRect, cachedGraphics.bitmap),
 								special.tileRect,
 								_flashPoint, _flashAlpha, _flashAlphaPoint, true);
-							
+
 							Buffer.dirty = (special.dirty || Buffer.dirty);
 						}
-					} 
-					
-					if (!isSpecial) 
+					}
+
+					if (!isSpecial)
 					{
 						Buffer.pixels.copyPixels(cachedGraphics.bitmap, _flashRect, _flashPoint, _flashAlpha, _flashAlphaPoint, true);
-					} 
-					else 
+					}
+					else
 					{
 						isSpecial = false;
 					}
-					
+
 					#if !FLX_NO_DEBUG
-					if (FlxG.debugger.visualDebug && !ignoreDrawDebug) 
+					if (FlxG.debugger.visualDebug && !ignoreDrawDebug)
 					{
 						tile = _tileObjects[_data[columnIndex]];
-						
+
 						if (tile != null)
 						{
 							if (tile.allowCollisions <= FlxObject.NONE)
 							{
 								// Blue
-								debugTile = _debugTileNotSolid; 
+								debugTile = _debugTileNotSolid;
 							}
 							else if (tile.allowCollisions != FlxObject.ANY)
 							{
 								// Pink
-								debugTile = _debugTilePartial; 
+								debugTile = _debugTilePartial;
 							}
 							else
 							{
 								// Green
-								debugTile = _debugTileSolid; 
+								debugTile = _debugTileSolid;
 							}
-							
+
 							Buffer.pixels.copyPixels(debugTile, _debugRect, _flashPoint, null, null, true);
 						}
 					}
@@ -272,32 +272,32 @@ class FlxTilemapExt extends FlxTilemap
 				}
 				#else
 				tileID = _rectIDs[columnIndex];
-				
+
 				if (tileID != -1)
 				{
-					if (_specialTiles != null) 
+					if (_specialTiles != null)
 					{
 						special = _specialTiles[columnIndex];
-					} 
-					else 
+					}
+					else
 					{
 						special = null;
 					}
-					
+
 					MATRIX.identity();
-					
-					if (special != null && special.isSpecial()) 
+
+					if (special != null && special.isSpecial())
 					{
 						MATRIX = special.getMatrix(_tileWidth, _tileHeight);
 						tileID = special.getCurrentTileId() - _startingIndex;
 					}
-					
+
 					drawX = _helperPoint.x + (columnIndex % widthInTiles) * _tileWidth;
 					drawY = _helperPoint.y + Math.floor(columnIndex / widthInTiles) * _tileHeight;
-					
+
 					drawX += MATRIX.tx;
 					drawY += MATRIX.ty;
-					
+
 					#if !js
 					currDrawData[currIndex++] = Math.floor(drawX) + 0.01;
 					currDrawData[currIndex++] = Math.floor(drawY) + 0.01;
@@ -306,43 +306,43 @@ class FlxTilemapExt extends FlxTilemap
 					currDrawData[currIndex++] = Math.floor(drawY);
 					#end
 					currDrawData[currIndex++] = tileID;
-					
-					
-					currDrawData[currIndex++] = MATRIX.a; 
+
+
+					currDrawData[currIndex++] = MATRIX.a;
 					currDrawData[currIndex++] = MATRIX.b;
 					currDrawData[currIndex++] = MATRIX.c;
-					currDrawData[currIndex++] = MATRIX.d; 
-					
+					currDrawData[currIndex++] = MATRIX.d;
+
 					#if !js
 					// Alpha
-					currDrawData[currIndex++] = alpha; 
+					currDrawData[currIndex++] = alpha;
 					#end
 				}
 				#end
-				
+
 				_flashPoint.x += _tileWidth;
 				column++;
 				columnIndex++;
 			}
-			
+
 			rowIndex += widthInTiles;
 			_flashPoint.y += _tileHeight;
 			row++;
 		}
-		
+
 		#if !flash
 		drawItem.position = currIndex;
 		#end
-		
+
 		Buffer.x = screenXInTiles * _tileWidth;
 		Buffer.y = screenYInTiles * _tileHeight;
 	}
-	
+
 	/**
 	 * Set the special tiles (rotated or flipped)
 	 * @param	tiles	An <code>Array</code> with all the <code>FlxTileSpecial</code>
 	 */
-	public function setSpecialTiles(tiles:Array<FlxTileSpecial>):Void 
+	public function setSpecialTiles(tiles:Array<FlxTileSpecial>):Void
 	{
 		_specialTiles = new Array<FlxTileSpecial>();
 
@@ -350,65 +350,65 @@ class FlxTilemapExt extends FlxTilemap
 		var animIds:Array<Int>;
 		#end
 		var t:FlxTileSpecial;
-		for (i in 0...tiles.length) 
+		for (i in 0...tiles.length)
 		{
 			t = tiles[i];
-			if (t != null && t.isSpecial()) 
+			if (t != null && t.isSpecial())
 			{
 				_specialTiles[i] = t;
-				
+
 				#if flash
 				// Update the tile animRects with the animation
-				if (t.hasAnimation()) 
+				if (t.hasAnimation())
 				{
 					animIds = t.getAnimationTilesId();
-					if (animIds != null) 
+					if (animIds != null)
 					{
 						var rectangles:Array<Rectangle> = new Array<Rectangle>();
 						var rectangle:Rectangle;
-						for (id in animIds) 
+						for (id in animIds)
 						{
 							rectangle = getRectangleFromTileset(id);
-							if (rectangle != null) 
+							if (rectangle != null)
 							{
 								rectangles.push(rectangle);
 							}
 						}
-						if (rectangles.length > 0) 
+						if (rectangles.length > 0)
 						{
 							t.setAnimationRects(rectangles);
 						}
 					}
-				}				
+				}
 				#end
-			} 
-			else 
+			}
+			else
 			{
 				_specialTiles[i] = null;
 			}
 		}
 	}
-	
-	private function getRectangleFromTileset(id:Int):Rectangle 
+
+	private function getRectangleFromTileset(id:Int):Rectangle
 	{
 		// Copied from FlxTilemap updateTile()
 		var tile:FlxTile = _tileObjects[id];
-		if (tile != null) 
+		if (tile != null)
 		{
 			var rx:Int = (id - _startingIndex) * (_tileWidth + region.spacingX);
 			var ry:Int = 0;
-		
+
 			if (Std.int(rx) >= region.width)
 			{
 				ry = Std.int(rx / region.width) * (_tileHeight + region.spacingY);
 				rx %= region.width;
 			}
-			
+
 			return new Rectangle(rx + region.startX, ry + region.startY, _tileWidth, _tileHeight);
 		}
 		return null;
 	}
-	
+
 	/**
 	 * THIS IS A COPY FROM <code>FlxTilemap</code>
 	 * I've only swapped lines 386 and 387 to give DrawTilemap() a chance to set the buffer dirty
@@ -421,53 +421,53 @@ class FlxTilemapExt extends FlxTilemap
 		{
 			cameras = FlxG.cameras.list;
 		}
-		
+
 		var camera:FlxCamera;
 		var buffer:FlxTilemapBuffer;
 		var i:Int = 0;
 		var l:Int = cameras.length;
-		
+
 		while (i < l)
 		{
 			camera = cameras[i];
-			
+
 			if (!camera.visible || !camera.exists)
 			{
 				continue;
 			}
-			
+
 			if (_buffers[i] == null)
 			{
 				_buffers[i] = new FlxTilemapBuffer(_tileWidth, _tileHeight, widthInTiles, heightInTiles, camera);
 				_buffers[i].forceComplexRender = forceComplexRender;
 			}
-			
+
 			buffer = _buffers[i++];
-			
+
 			#if flash
 			if (!buffer.dirty)
 			{
 				// Copied from getScreenXY()
-				_point.x = x - (camera.scroll.x * scrollFactor.x) + buffer.x; 
+				_point.x = x - (camera.scroll.x * scrollFactor.x) + buffer.x;
 				_point.y = y - (camera.scroll.y * scrollFactor.y) + buffer.y;
 				buffer.dirty = (_point.x > 0) || (_point.y > 0) || (_point.x + buffer.width < camera.width) || (_point.y + buffer.height < camera.height);
 			}
-			
+
 			if (buffer.dirty)
 			{
 				buffer.dirty = false;
 				drawTilemap(buffer, camera);
 			}
-			
+
 			// Copied from getScreenXY()
-			_flashPoint.x = x - (camera.scroll.x * scrollFactor.x) + buffer.x; 
+			_flashPoint.x = x - (camera.scroll.x * scrollFactor.x) + buffer.x;
 			_flashPoint.y = y - (camera.scroll.y * scrollFactor.y) + buffer.y;
 			buffer.draw(camera, _flashPoint);
-			
+
 			#else
 			drawTilemap(buffer, camera);
 			#end
-			
+
 			#if !FLX_NO_DEBUG
 			FlxBasic._VISIBLECOUNT++;
 			#end
@@ -490,22 +490,22 @@ class FlxTilemapExt extends FlxTilemap
 	override public function overlapsWithCallback(Object:FlxObject, ?Callback:FlxObject->FlxObject->Bool, FlipCallbackParams:Bool = false, ?Position:FlxPoint):Bool
 	{
 		var results:Bool = false;
-		
+
 		var X:Float = x;
 		var Y:Float = y;
-		
+
 		if (Position != null)
 		{
 			X = Position.x;
 			Y = Position.y;
 		}
-		
+
 		//Figure out what tiles we need to check against
 		var selectionX:Int = Math.floor((Object.x - X) / _tileWidth);
 		var selectionY:Int = Math.floor((Object.y - Y) / _tileHeight);
 		var selectionWidth:Int = selectionX + (Math.ceil(Object.width / _tileWidth)) + 1;
 		var selectionHeight:Int = selectionY + Math.ceil(Object.height / _tileHeight) + 1;
-		
+
 		//Then bound these coordinates by the map edges
 		if (selectionX < 0)
 		{
@@ -523,7 +523,7 @@ class FlxTilemapExt extends FlxTilemap
 		{
 			selectionHeight = heightInTiles;
 		}
-		
+
 		// Then loop through this selection of tiles and call FlxObject.separate() accordingly
 		var rowStart:Int = selectionY * widthInTiles;
 		var row:Int = selectionY;
@@ -532,23 +532,23 @@ class FlxTilemapExt extends FlxTilemap
 		var overlapFound:Bool;
 		var deltaX:Float = X - last.x;
 		var deltaY:Float = Y - last.y;
-		
+
 		while (row < selectionHeight)
 		{
 			column = selectionX;
-			
+
 			while (column < selectionWidth)
 			{
 				overlapFound = false;
 				tile = _tileObjects[_data[rowStart + column]];
-				
+
 				if (tile.allowCollisions != 0)
 				{
 					tile.x = X + column * _tileWidth;
 					tile.y = Y + row * _tileHeight;
 					tile.last.x = tile.x - deltaX;
 					tile.last.y = tile.y - deltaY;
-					
+
 					if (Callback != null)
 					{
 						if (FlipCallbackParams)
@@ -564,13 +564,13 @@ class FlxTilemapExt extends FlxTilemap
 					{
 						overlapFound = (Object.x + Object.width > tile.x) && (Object.x < tile.x + tile.width) && (Object.y + Object.height > tile.y) && (Object.y < tile.y + tile.height);
 					}
-					
+
 					// Solve slope collisions if no overlap was found
 					/*
 					if (overlapFound
 						|| (!overlapFound && (tile.index == SLOPE_FLOOR_LEFT || tile.index == SLOPE_FLOOR_RIGHT || tile.index == SLOPE_CEIL_LEFT || tile.index == SLOPE_CEIL_RIGHT)))
 					*/
-					
+
 					// New generalized slope collisions
 					if (overlapFound || (!overlapFound && checkArrays(tile.index)))
 					{
@@ -589,17 +589,17 @@ class FlxTilemapExt extends FlxTilemap
 				}
 				column++;
 			}
-			
+
 			rowStart += widthInTiles;
 			row++;
 		}
-		
+
 		return results;
 	}
-	
+
 	/**
 	 * Sets the tiles that are treated as "clouds" or blocks that are only solid from the top.
-	 * 
+	 *
 	 * @param 	Clouds	An array containing the numbers of the tiles to be treated as clouds.
 	 */
 	public function setClouds(?Clouds:Array<Int>):Void
@@ -608,14 +608,14 @@ class FlxTilemapExt extends FlxTilemap
 		{
 			for (i in 0...(Clouds.length))
 			{
-				setTileProperties(Clouds[i], FlxObject.CEILING);			
+				setTileProperties(Clouds[i], FlxObject.CEILING);
 			}
 		}
 	}
-	
+
 	/**
 	 * Sets the slope arrays, which define which tiles are treated as slopes.
-	 * 
+	 *
 	 * @param 	LeftFloorSlopes 	An array containing the numbers of the tiles to be treated as left floor slopes.
 	 * @param 	RightFloorSlopes	An array containing the numbers of the tiles to be treated as right floor slopes.
 	 * @param 	LeftCeilSlopes		An array containing the numbers of the tiles to be treated as left ceiling slopes.
@@ -639,13 +639,13 @@ class FlxTilemapExt extends FlxTilemap
 		{
 			_slopeCeilRight = RightCeilSlopes;
 		}
-		
+
 		setSlopeProperties();
 	}
-	
+
 	/**
 	 * Bounds the slope point to the slope
-	 * 
+	 *
 	 * @param 	Slope 	The slope to fix the slopePoint for
 	 */
 	private function fixSlopePoint(Slope:FlxTile):Void
@@ -653,10 +653,10 @@ class FlxTilemapExt extends FlxTilemap
 		_slopePoint.x = FlxMath.bound(_slopePoint.x, Slope.x, Slope.x + _tileWidth);
 		_slopePoint.y = FlxMath.bound(_slopePoint.y, Slope.y, Slope.y + _tileHeight);
 	}
-	
+
 	/**
 	 * Ss called if an object collides with a floor slope
-	 * 
+	 *
 	 * @param 	Slope	The floor slope
 	 * @param	Object 	The object that collides with that slope
 	 */
@@ -664,22 +664,22 @@ class FlxTilemapExt extends FlxTilemap
 	{
 		// Set the object's touching flag
 		Object.touching = FlxObject.FLOOR;
-		
+
 		// Adjust the object's velocity
 		Object.velocity.y = 0;
-		
+
 		// Reposition the object
 		Object.y = _slopePoint.y - Object.height;
-		
-		if (Object.y < Slope.y - Object.height) 
-		{ 
-			Object.y = Slope.y - Object.height; 
+
+		if (Object.y < Slope.y - Object.height)
+		{
+			Object.y = Slope.y - Object.height;
 		}
 	}
-	
+
 	/**
 	 * Is called if an object collides with a ceiling slope
-	 * 
+	 *
 	 * @param 	Slope 	The ceiling slope
 	 * @param 	Object 	The object that collides with that slope
 	 */
@@ -687,22 +687,22 @@ class FlxTilemapExt extends FlxTilemap
 	{
 		// Set the object's touching flag
 		Object.touching = FlxObject.CEILING;
-		
+
 		// Adjust the object's velocity
 		Object.velocity.y = 0;
-		
+
 		// Reposition the object
 		Object.y = _slopePoint.y;
-		
-		if (Object.y > Slope.y + _tileHeight) 
-		{ 
-			Object.y = Slope.y + _tileHeight; 
+
+		if (Object.y > Slope.y + _tileHeight)
+		{
+			Object.y = Slope.y + _tileHeight;
 		}
 	}
-	
+
 	/**
 	 * Solves collision against a left-sided floor slope
-	 * 
+	 *
 	 * @param 	Slope 	The slope to check against
 	 * @param 	Object 	The object that collides with the slope
 	 */
@@ -711,15 +711,15 @@ class FlxTilemapExt extends FlxTilemap
 		// Calculate the corner point of the object
 		_objPoint.x = Math.floor(Object.x + Object.width + _snapping);
 		_objPoint.y = Math.floor(Object.y + Object.height);
-		
+
 		// Calculate position of the point on the slope that the object might overlap
 		// this would be one side of the object projected onto the slope's surface
 		_slopePoint.x = _objPoint.x;
 		_slopePoint.y = (Slope.y + _tileHeight) - (_slopePoint.x - Slope.x);
-		
+
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));
-		
+
 		// Check if the object is inside the slope
 		if (_objPoint.x > Slope.x + _snapping && _objPoint.x < Slope.x + _tileWidth + Object.width + _snapping && _objPoint.y >= _slopePoint.y && _objPoint.y <= Slope.y + _tileHeight)
 		{
@@ -727,10 +727,10 @@ class FlxTilemapExt extends FlxTilemap
 			onCollideFloorSlope(Slope, Object);
 		}
 	}
-	
+
 	/**
 	 * Solves collision against a right-sided floor slope
-	 * 
+	 *
 	 * @param 	Slope 	The slope to check against
 	 * @param 	Object 	The object that collides with the slope
 	 */
@@ -739,15 +739,15 @@ class FlxTilemapExt extends FlxTilemap
 		// Calculate the corner point of the object
 		_objPoint.x = Math.floor(Object.x - _snapping);
 		_objPoint.y = Math.floor(Object.y + Object.height);
-		
+
 		// Calculate position of the point on the slope that the object might overlap
 		// this would be one side of the object projected onto the slope's surface
 		_slopePoint.x = _objPoint.x;
 		_slopePoint.y = (Slope.y + _tileHeight) - (Slope.x - _slopePoint.x + _tileWidth);
-		
+
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));
-		
+
 		// Check if the object is inside the slope
 		if (_objPoint.x > Slope.x - Object.width - _snapping && _objPoint.x < Slope.x + _tileWidth + _snapping && _objPoint.y >= _slopePoint.y && _objPoint.y <= Slope.y + _tileHeight)
 		{
@@ -755,10 +755,10 @@ class FlxTilemapExt extends FlxTilemap
 			onCollideFloorSlope(Slope, Object);
 		}
 	}
-	
+
 	/**
 	 * Solves collision against a left-sided ceiling slope
-	 * 
+	 *
 	 * @param 	Slope 	The slope to check against
 	 * @param 	Obj 	The object that collides with the slope
 	 */
@@ -767,15 +767,15 @@ class FlxTilemapExt extends FlxTilemap
 		// Calculate the corner point of the object
 		_objPoint.x = Math.floor(Obj.x + Obj.width + _snapping);
 		_objPoint.y = Math.ceil(Obj.y);
-		
+
 		// Calculate position of the point on the slope that the object might overlap
 		// this would be one side of the object projected onto the slope's surface
 		_slopePoint.x = _objPoint.x;
 		_slopePoint.y = (Slope.y) + (_slopePoint.x - Slope.x);
-		
+
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));
-		
+
 		// Check if the object is inside the slope
 		if (_objPoint.x > Slope.x + _snapping && _objPoint.x < Slope.x + _tileWidth + Obj.width + _snapping && _objPoint.y <= _slopePoint.y && _objPoint.y >= Slope.y)
 		{
@@ -783,10 +783,10 @@ class FlxTilemapExt extends FlxTilemap
 			onCollideCeilSlope(Slope, Obj);
 		}
 	}
-	
+
 	/**
 	 * Solves collision against a right-sided ceiling slope
-	 * 
+	 *
 	 * @param 	Slope 	The slope to check against
 	 * @param 	Obj 	The object that collides with the slope
 	 */
@@ -795,15 +795,15 @@ class FlxTilemapExt extends FlxTilemap
 		// Calculate the corner point of the object
 		_objPoint.x = Math.floor(Obj.x - _snapping);
 		_objPoint.y = Math.ceil(Obj.y);
-		
+
 		// Calculate position of the point on the slope that the object might overlap
 		// this would be one side of the object projected onto the slope's surface
 		_slopePoint.x = _objPoint.x;
 		_slopePoint.y = (Slope.y) + (Slope.x - _slopePoint.x + _tileWidth);
-		
+
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));
-		
+
 		// Check if the object is inside the slope
 		if (_objPoint.x > Slope.x - Obj.width - _snapping && _objPoint.x < Slope.x + _tileWidth + _snapping && _objPoint.y <= _slopePoint.y && _objPoint.y >= Slope.y)
 		{
@@ -811,7 +811,7 @@ class FlxTilemapExt extends FlxTilemap
 			onCollideCeilSlope(Slope, Obj);
 		}
 	}
-	
+
 	/**
 	 * Internal helper function for setting the tiles currently held in the slope arrays to use slope collision.
 	 * Note that if you remove items from a slope, this function will not unset the slope property.
@@ -820,7 +820,7 @@ class FlxTilemapExt extends FlxTilemap
 	{
 		for (i in 0..._slopeFloorLeft.length)
 		{
-			setTileProperties(_slopeFloorLeft[i], FlxObject.RIGHT | FlxObject.FLOOR, solveCollisionSlopeFloorLeft);			
+			setTileProperties(_slopeFloorLeft[i], FlxObject.RIGHT | FlxObject.FLOOR, solveCollisionSlopeFloorLeft);
 		}
 		for (i in 0..._slopeFloorRight.length)
 		{
@@ -828,17 +828,17 @@ class FlxTilemapExt extends FlxTilemap
 		}
 		for (i in 0..._slopeCeilLeft.length)
 		{
-			setTileProperties(_slopeCeilLeft[i], FlxObject.RIGHT | FlxObject.CEILING, solveCollisionSlopeCeilLeft);			
+			setTileProperties(_slopeCeilLeft[i], FlxObject.RIGHT | FlxObject.CEILING, solveCollisionSlopeCeilLeft);
 		}
 		for (i in 0..._slopeCeilRight.length)
 		{
 			setTileProperties(_slopeCeilRight[i], FlxObject.LEFT | FlxObject.CEILING, solveCollisionSlopeCeilRight);
 		}
 	}
-	
+
 	/**
 	 * Internal helper function for comparing a tile to the slope arrays to see if a tile should be treated as a slope.
-	 * 
+	 *
 	 * @param 	TileIndex	The Tile Index number of the Tile you want to check.
 	 * @return	Returns true if the tile is listed in one of the slope arrays. Otherwise returns false.
 	 */
@@ -850,29 +850,29 @@ class FlxTilemapExt extends FlxTilemap
 			{
 				return true;
 			}
-		}	
+		}
 		for (i in 0..._slopeFloorRight.length)
 		{
 			if (_slopeFloorRight[i] == TileIndex)
 			{
 				return true;
 			}
-		}	
+		}
 		for (i in 0..._slopeCeilLeft.length)
 		{
 			if (_slopeCeilLeft[i] == TileIndex)
 			{
 				return true;
 			}
-		}	
+		}
 		for (i in 0..._slopeCeilRight.length)
 		{
 			if (_slopeCeilRight[i] == TileIndex)
 			{
 				return true;
 			}
-		}	
-		
+		}
+
 		return false;
 	}
 }

--- a/flixel/addons/ui/FlxButtonPlus.hx
+++ b/flixel/addons/ui/FlxButtonPlus.hx
@@ -6,21 +6,21 @@ import flash.events.MouseEvent;
 import flash.geom.Rectangle;
 import flash.Lib;
 import flixel.addons.display.FlxExtendedSprite;
-import flixel.FlxCamera;
-import flixel.FlxG;
-import flixel.FlxSprite;
-import flixel.group.FlxSpriteGroup;
-import flixel.text.FlxText;
-import flixel.util.FlxColor;
-import flixel.util.FlxGradient;
-import flixel.util.FlxMath;
-import flixel.util.loaders.CachedGraphics;
+import org.flixel.FlxCamera;
+import org.flixel.FlxG;
+import org.flixel.FlxSprite;
+import org.flixel.group.FlxSpriteGroup;
+import org.flixel.text.FlxText;
+import org.flixel.util.FlxColor;
+import org.flixel.util.FlxGradient;
+import org.flixel.util.FlxMath;
+import org.flixel.util.loaders.CachedGraphics;
 
 //TODO: Port to use touch as well
 
 /**
  * A simple button class that calls a function when clicked by the mouse.
- * 
+ *
  * @link http://www.photonstorm.com
  * @author Richard Davey / Photon Storm
  */
@@ -29,13 +29,13 @@ class FlxButtonPlus extends FlxSpriteGroup
 	inline static public var NORMAL:Int = 0;
 	inline static public var HIGHLIGHT:Int = 1;
 	inline static public var PRESSED:Int = 2;
-	
+
 	public var buttonNormal:FlxExtendedSprite;
 	public var buttonHighlight:FlxExtendedSprite;
-	
+
 	public var textNormal:FlxText;
 	public var textHighlight:FlxText;
-	
+
 	/**
 	 * The 1px thick border color that is drawn around this button
 	 */
@@ -48,10 +48,10 @@ class FlxButtonPlus extends FlxSpriteGroup
 	 * The color gradient of the button in its hovered state
 	 */
 	public var onColor:Array<Int>;
-	
+
 	public var width:Int;
 	public var height:Int;
-	
+
 	/**
 	 * Set this to true if you want this button to function even while the game is paused.
 	 */
@@ -59,7 +59,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 	/**
 	 * Shows the current state of the button.
 	 */
-	
+
 	private var _status:Int;
 	/**
 	 * This function is called when the button is clicked.
@@ -93,11 +93,11 @@ class FlxButtonPlus extends FlxSpriteGroup
 	 * The parameters passed to the leaveCallback function when the hovered button is left
 	 */
 	private var _leaveCallbackParams:Array<Dynamic>;
-	
+
 	/**
 	 * Creates a new <code>FlxButton</code> object with a gray background
 	 * and a callback function on the UI thread.
-	 * 
+	 *
 	 * @param	X			The X position of the button.
 	 * @param	Y			The Y position of the button.
 	 * @param	Callback	The function to call whenever the button is clicked.
@@ -110,49 +110,49 @@ class FlxButtonPlus extends FlxSpriteGroup
 	{
 		offColor = [0xff008000, 0xff00ff00];
 		onColor = [0xff800000, 0xffff0000];
-		
+
 		super(4);
-		
+
 		x = X;
 		y = Y;
 		width = Width;
 		height = Height;
 		_onClick = Callback;
-		
+
 		buttonNormal = new FlxExtendedSprite();
-		
+
 		#if flash
 		buttonNormal.makeGraphic(Width, Height, borderColor);
 		#end
-		
+
 		updateInactiveButtonColors(offColor);
-		
+
 		buttonNormal.solid = false;
 		buttonNormal.scrollFactor.set();
-		
+
 		buttonHighlight = new FlxExtendedSprite();
-		
+
 		#if flash
 		buttonHighlight.makeGraphic(Width, Height, borderColor);
 		#end
-		
+
 		updateActiveButtonColors(onColor);
-		
+
 		buttonHighlight.solid = false;
 		buttonHighlight.visible = false;
 		buttonHighlight.scrollFactor.set();
-		
+
 		add(buttonNormal);
 		add(buttonHighlight);
-		
+
 		if (Label != null)
 		{
 			textNormal = new FlxText(0, 3, Width, Label);
 			textNormal.setFormat(null, 8, 0xffffff, "center", 0x000000);
-			
+
 			textHighlight = new FlxText(0, 3, Width, Label);
 			textHighlight.setFormat(null, 8, 0xffffff, "center", 0x000000);
-			
+
 			add(textNormal);
 			add(textHighlight);
 		}
@@ -161,7 +161,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 		_pressed = false;
 		_initialized = false;
 		pauseProof = false;
-		
+
 		if (Params != null)
 		{
 			_onClickParams = Params;
@@ -171,12 +171,12 @@ class FlxButtonPlus extends FlxSpriteGroup
 			_onClickParams = [];
 		}
 	}
-	
+
 	/**
 	 * If you wish to replace the two buttons (normal and hovered-over) with FlxSprites, then pass them here.<br />
 	 * Note: The pixel data is extract from the passed FlxSprites and assigned locally, it doesn't actually use the sprites<br />
 	 * or keep a reference to them.
-	 * 
+	 *
 	 * @param	Normal		The FlxSprite to use when the button is in-active (not hovered over)
 	 * @param	Highlight	The FlxSprite to use when the button is hovered-over by the mouse
 	 */
@@ -184,7 +184,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 	{
 		buttonNormal.pixels = Normal.pixels;
 		buttonHighlight.pixels = Highlight.pixels;
-		
+
 		width = Std.int(buttonNormal.width);
 		height = Std.int(buttonNormal.height);
 
@@ -197,7 +197,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 			buttonHighlight.visible = false;
 		}
 	}
-	
+
 	/**
 	 * Called by the game loop automatically, handles mouseover and click detection.
 	 */
@@ -211,68 +211,68 @@ class FlxButtonPlus extends FlxSpriteGroup
 				_initialized = true;
 			}
 		}
-		
+
 		super.update();
-		
+
 		//Basic button logic
-		updateButton(); 
+		updateButton();
 	}
-	
+
 	/**
 	 * Basic button update logic
 	 */
 	function updateButton():Void
 	{
 		var prevStatus:Int = _status;
-		
+
 		if (buttonNormal.cameras == null)
 		{
 			buttonNormal.cameras = FlxG.cameras.list;
 		}
-		
+
 		var c:FlxCamera;
 		var i:Int = 0;
 		var l:Int = buttonNormal.cameras.length;
 		var offAll:Bool = true;
-		
+
 		while (i < l)
 		{
 			c = buttonNormal.cameras[i++];
-			
+
 			if (FlxMath.mouseInFlxRect(false, buttonNormal.rect))
 			{
 				offAll = false;
-				
+
 				if (FlxG.mouse.justPressed)
 				{
 					_status = PRESSED;
 				}
-				
+
 				if (_status == NORMAL)
 				{
 					_status = HIGHLIGHT;
 				}
 			}
 		}
-		
+
 		if (offAll)
 		{
 			_status = NORMAL;
 		}
-		
+
 		if (_status != prevStatus)
 		{
 			if (_status == NORMAL)
 			{
 				buttonNormal.visible = true;
 				buttonHighlight.visible = false;
-				
+
 				if (textNormal != null)
 				{
 					textNormal.visible = true;
 					textHighlight.visible = false;
 				}
-				
+
 				if (_leaveCallback != null)
 				{
 					Reflect.callMethod(null, _leaveCallback, _leaveCallbackParams);
@@ -282,13 +282,13 @@ class FlxButtonPlus extends FlxSpriteGroup
 			{
 				buttonNormal.visible = false;
 				buttonHighlight.visible = true;
-				
+
 				if (textNormal != null)
 				{
 					textNormal.visible = false;
 					textHighlight.visible = true;
 				}
-				
+
 				if (_enterCallback != null)
 				{
 					Reflect.callMethod(null, _enterCallback, _enterCallbackParams);
@@ -296,9 +296,9 @@ class FlxButtonPlus extends FlxSpriteGroup
 			}
 		}
 	}
-	
+
 	/**
-	 * WARNING: This will remove this object entirely. Use <code>kill()</code> if you 
+	 * WARNING: This will remove this object entirely. Use <code>kill()</code> if you
 	 * want to disable it temporarily only and <code>reset()</code> it later to revive it.
 	 * Called by the game state when state is changed (if this object belongs to the state)
 	 */
@@ -308,38 +308,38 @@ class FlxButtonPlus extends FlxSpriteGroup
 		{
 			Lib.current.stage.removeEventListener(MouseEvent.MOUSE_UP, onMouseUp);
 		}
-		
+
 		if (buttonNormal != null)
 		{
 			buttonNormal.destroy();
 			buttonNormal = null;
 		}
-		
+
 		if (buttonHighlight != null)
 		{
 			buttonHighlight.destroy();
 			buttonHighlight = null;
 		}
-		
+
 		if (textNormal != null)
 		{
 			textNormal.destroy();
 			textNormal = null;
 		}
-		
+
 		if (textHighlight != null)
 		{
 			textHighlight.destroy();
 			textHighlight = null;
 		}
-		
+
 		_onClick = null;
 		_enterCallback = null;
 		_leaveCallback = null;
-		
+
 		super.destroy();
 	}
-	
+
 	/**
 	 * Internal function for handling the actual callback call (for UI thread dependent calls like <code>FlxMisc.openURL()</code>).
 	 */
@@ -350,90 +350,90 @@ class FlxButtonPlus extends FlxSpriteGroup
 			Reflect.callMethod(this, Reflect.getProperty(this, "_onClick"), _onClickParams);
 		}
 	}
-	
+
 	/**
 	 * If you want to change the color of this button in its in-active (not hovered over) state, then pass a new array of color values
-	 * 
+	 *
 	 * @param	colors
 	 */
 	public function updateInactiveButtonColors(Colors:Array<Int>):Void
 	{
 		offColor = Colors;
-		
+
 		#if flash
 		buttonNormal.stamp(FlxGradient.createGradientFlxSprite(width - 2, height - 2, offColor), 1, 1);
 		#else
 		var colA:Int;
 		var colRGB:Int;
-		
+
 		var normalKey:String = "Gradient: " + width + " x " + height + ", colors: [";
-		
+
 		for (col in offColor)
 		{
 			colA = (col >> 24) & 255;
 			colRGB = col & 0x00ffffff;
-			
+
 			normalKey = normalKey + colRGB + "_" + colA + ", ";
 		}
-		
+
 		normalKey = normalKey + "]";
-		
+
 		if (FlxG.bitmap.checkCache(normalKey) == false)
 		{
 			var normalGraphics:CachedGraphics = FlxG.bitmap.create(width, height, FlxColor.TRANSPARENT, false, normalKey);
 			normalGraphics.bitmap.fillRect(new Rectangle(0, 0, width, height), borderColor);
 			FlxGradient.overlayGradientOnBitmapData(normalGraphics.bitmap, width - 2, height - 2, offColor, 1, 1);
 		}
-		
+
 		buttonNormal.pixels = FlxG.bitmap.get(normalKey).bitmap;
 		#end
 	}
-	
+
 	/**
 	 * If you want to change the color of this button in its active (hovered over) state, then pass a new array of color values
-	 * 
+	 *
 	 * @param	Colors
 	 */
 	public function updateActiveButtonColors(Colors:Array<Int>):Void
 	{
 		onColor = Colors;
-		
+
 		#if flash
 		buttonHighlight.stamp(FlxGradient.createGradientFlxSprite(width - 2, height - 2, onColor), 1, 1);
 		#else
-		
+
 		var colA:Int;
 		var colRGB:Int;
-		
+
 		var highlightKey:String = "Gradient: " + width + " x " + height + ", colors: [";
-		
+
 		for (col in onColor)
 		{
 			colA = (col >> 24) & 255;
 			colRGB = col & 0x00ffffff;
-			
+
 			highlightKey = highlightKey + colRGB + "_" + colA + ", ";
 		}
-		
+
 		highlightKey = highlightKey + "]";
-		
+
 		if (FlxG.bitmap.checkCache(highlightKey) == false)
 		{
 			var highlightGraphics:CachedGraphics = FlxG.bitmap.create(width, height, FlxColor.TRANSPARENT, false, highlightKey);
 			highlightGraphics.bitmap.fillRect(new Rectangle(0, 0, width, height), borderColor);
 			FlxGradient.overlayGradientOnBitmapData(highlightGraphics.bitmap, width - 2, height - 2, onColor, 1, 1);
 		}
-		
+
 		buttonHighlight.pixels = FlxG.bitmap.get(highlightKey).bitmap;
 		#end
 	}
-	
+
 	/**
 	 * If this button has text, set this to change the value
 	 */
-	
+
 	public var text(never, set):String;
-	
+
 	public function set_text(NewText:String):String
 	{
 		if (textNormal != null && textNormal.text != NewText)
@@ -441,10 +441,10 @@ class FlxButtonPlus extends FlxSpriteGroup
 			textNormal.text = NewText;
 			textHighlight.text = NewText;
 		}
-		
+
 		return NewText;
 	}
-	
+
 	/**
 	 * Center this button (on the X axis) Uses <code>FlxG.width / 2 - button width / 2</code>
 	 * to achieve this. Doesn't take scrolling into consideration.
@@ -453,24 +453,24 @@ class FlxButtonPlus extends FlxSpriteGroup
 	{
 		buttonNormal.x = (FlxG.width / 2) - (width / 2);
 		buttonHighlight.x = (FlxG.width / 2) - (width / 2);
-		
+
 		if (textNormal != null)
 		{
 			textNormal.x = buttonNormal.x;
 			textHighlight.x = buttonHighlight.x;
 		}
 	}
-	
+
 	/**
 	 * Sets a callback function for when this button is rolled-over with the mouse
-	 * 
+	 *
 	 * @param	Callback	The function to call, will be called once when the mouse enters
 	 * @param	Params		An optional array of parameters to pass to the function
 	 */
 	public function setMouseOverCallback(Callback:Dynamic, ?Params:Array<Dynamic>):Void
 	{
 		_enterCallback = Callback;
-		
+
 		if (Params != null)
 		{
 			_enterCallbackParams = Params;
@@ -480,17 +480,17 @@ class FlxButtonPlus extends FlxSpriteGroup
 			_enterCallbackParams = [];
 		}
 	}
-	
+
 	/**
 	 * Sets a callback function for when the mouse rolls-out of this button
-	 * 
+	 *
 	 * @param	Callback	The function to call, will be called once when the mouse leaves the button
 	 * @param	Params		An optional array of parameters to pass to the function
 	 */
 	public function setMouseOutCallback(Callback:Dynamic, ?Params:Array<Dynamic>):Void
 	{
 		_leaveCallback = Callback;
-		
+
 		if (Params != null)
 		{
 			_leaveCallbackParams = Params;
@@ -500,11 +500,11 @@ class FlxButtonPlus extends FlxSpriteGroup
 			_leaveCallbackParams = [];
 		}
 	}
-	
+
 	public function setOnClickCallback(Callback:Dynamic, Params:Array<Dynamic> = null):Void
 	{
 		_onClick = Callback;
-		
+
 		if (Params != null)
 		{
 			_onClickParams = Params;

--- a/flixel/addons/weapon/FlxBullet.hx
+++ b/flixel/addons/weapon/FlxBullet.hx
@@ -1,13 +1,13 @@
 package flixel.addons.weapon;
 
-import flixel.FlxG;
-import flixel.FlxSprite;
-import flixel.system.input.touch.FlxTouch;
-import flixel.util.FlxAngle;
-import flixel.util.FlxMath;
-import flixel.util.FlxPoint;
-import flixel.util.FlxRandom;
-import flixel.util.FlxVelocity;
+import org.flixel.FlxG;
+import org.flixel.FlxSprite;
+import org.flixel.system.input.touch.FlxTouch;
+import org.flixel.util.FlxAngle;
+import org.flixel.util.FlxMath;
+import org.flixel.util.FlxPoint;
+import org.flixel.util.FlxRandom;
+import org.flixel.util.FlxVelocity;
 
 /**
  * @link http://www.photonstorm.com
@@ -21,29 +21,29 @@ class FlxBullet extends FlxSprite
 	public var accelerates:Bool = false;
 	public var xAcceleration:Int;
 	public var yAcceleration:Int;
-	
+
 	public var rndFactorAngle:Int;
 	public var rndFactorSpeed:Int;
 	public var rndFactorLifeSpan:Int;
 	public var lifespan:Float;
-	
+
 	private var _weapon:FlxWeapon;
 	private var _animated:Bool = false;
 	private var _bulletSpeed:Int = 0;
-	
+
 	public function new(Weapon:FlxWeapon, WeaponID:Int)
 	{
 		super(0, 0);
-		
+
 		_weapon = Weapon;
 		ID = WeaponID;
-		
+
 		exists = false;
 	}
-	
+
 	/**
 	 * Adds a new animation to the sprite.
-	 * 
+	 *
 	 * @param	Name		What this animation should be called (e.g. "run").
 	 * @param	Frames		An array of numbers indicating what frames to play in what order (e.g. 1, 2, 3).
 	 * @param	FrameRate	The speed in frames per second that the animation should play at (e.g. 40 fps).
@@ -52,15 +52,15 @@ class FlxBullet extends FlxSprite
 	override public function addAnimation(Name:String, Frames:Array<Int>, FrameRate:Int = 0, Looped:Bool = true):Void
 	{
 		super.addAnimation(Name, Frames, FrameRate, Looped);
-		
+
 		_animated = true;
 	}
-	
+
 	public function fire(FromX:Float, FromY:Float, VelX:Float, VelY:Float):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		if (accelerates)
 		{
 			acceleration.x = xAcceleration + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed);
@@ -71,16 +71,16 @@ class FlxBullet extends FlxSprite
 			velocity.x = VelX + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed);
 			velocity.y = VelY + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed);
 		}
-		
+
 		postFire();
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	public function fireAtMouse(FromX:Float, FromY:Float, Speed:Int, RotateBulletTowards = true):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		if (accelerates)
 		{
 			FlxVelocity.accelerateTowardsMouse(this, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed), Math.floor(maxVelocity.x), Math.floor(maxVelocity.y));
@@ -89,22 +89,22 @@ class FlxBullet extends FlxSprite
 		{
 			FlxVelocity.moveTowardsMouse(this, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed));
 		}
-		
+
 		if (RotateBulletTowards)
 		{
 			angle = FlxAngle.angleBetweenMouse(_weapon.parent, true);
 		}
-		
+
 		postFire();
 	}
 	#end
-	
+
 	#if !FLX_NO_TOUCH
 	public function fireAtTouch(FromX:Float, FromY:Float, Touch:FlxTouch, Speed:Int, RotateBulletTowards = true):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		if (accelerates)
 		{
 			FlxVelocity.accelerateTowardsTouch(this, Touch, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed), Math.floor(maxVelocity.x), Math.floor(maxVelocity.y));
@@ -113,21 +113,21 @@ class FlxBullet extends FlxSprite
 		{
 			FlxVelocity.moveTowardsTouch(this, Touch, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed));
 		}
-		
+
 		if (RotateBulletTowards)
 		{
 			angle = FlxAngle.angleBetweenTouch(_weapon.parent, Touch, true);
 		}
-		
+
 		postFire();
 	}
 	#end
-	
+
 	public function fireAtPosition(FromX:Float, FromY:Float, ToX:Float, ToY:Float, Speed:Int):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		if (accelerates)
 		{
 			FlxVelocity.accelerateTowardsPoint(this, new FlxPoint(ToX, ToY), Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed), Math.floor(maxVelocity.x), Math.floor(maxVelocity.y));
@@ -136,15 +136,15 @@ class FlxBullet extends FlxSprite
 		{
 			FlxVelocity.moveTowardsPoint(this, new FlxPoint(ToX, ToY), Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed));
 		}
-		
+
 		postFire();
 	}
-	
+
 	public function fireAtTarget(FromX:Float, FromY:Float, Target:FlxSprite, Speed:Int):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		if (accelerates)
 		{
 			FlxVelocity.accelerateTowardsObject(this, Target, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed), Math.floor(maxVelocity.x), Math.floor(maxVelocity.y));
@@ -153,17 +153,17 @@ class FlxBullet extends FlxSprite
 		{
 			FlxVelocity.moveTowardsObject(this, Target, Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed));
 		}
-		
+
 		postFire();
 	}
-	
+
 	public function fireFromAngle(FromX:Float, FromY:Float, FireAngle:Int, Speed:Int):Void
 	{
 		x = FromX + FlxRandom.floatRanged( -_weapon.rndFactorPosition.x, _weapon.rndFactorPosition.x);
 		y = FromY + FlxRandom.floatRanged( -_weapon.rndFactorPosition.y, _weapon.rndFactorPosition.y);
-		
+
 		var newVelocity:FlxPoint = FlxVelocity.velocityFromAngle(FireAngle + FlxRandom.intRanged( -_weapon.rndFactorAngle, _weapon.rndFactorAngle), Speed + FlxRandom.intRanged( -_weapon.rndFactorSpeed, _weapon.rndFactorSpeed));
-		
+
 		if (accelerates)
 		{
 			acceleration.x = newVelocity.x;
@@ -174,89 +174,89 @@ class FlxBullet extends FlxSprite
 			velocity.x = newVelocity.x;
 			velocity.y = newVelocity.y;
 		}
-		
+
 		postFire();
 	}
-	
+
 	private function postFire():Void
 	{
 		if (_animated)
 		{
 			play("fire");
 		}
-		
+
 		if (_weapon.bulletElasticity > 0)
 		{
 			elasticity = _weapon.bulletElasticity;
 		}
-		
+
 		exists = true;
-		
+
 		// Reset last x and y position in case we were recycled.
 		last.x = x;
 		last.y = y;
-		
+
 		if (_weapon.bulletLifeSpan > 0)
 		{
 			lifespan = _weapon.bulletLifeSpan + FlxRandom.floatRanged(-_weapon.rndFactorLifeSpan, _weapon.rndFactorLifeSpan);
 		}
-		
+
 		if (_weapon.onFireCallback != null)
 		{
 			_weapon.onFireCallback();
 		}
-		
+
 		if (_weapon.onFireSound != null)
 		{
 			_weapon.onFireSound.play();
 		}
 	}
-	
+
 	public var xGravity(never, set):Float;
-	
+
 	private function set_xGravity(NewXGravity:Float):Float
 	{
 		return acceleration.x = NewXGravity;
 	}
-	
+
 	public var yGravity(never, set):Float;
-	
+
 	private function set_yGravity(NewYGravity:Float):Float
 	{
 		return acceleration.y = NewYGravity;
 	}
-	
+
 	public var maxVelocityX(never, set):Float;
-	
+
 	private function set_maxVelocityX(MaxXVelocity:Float):Float
 	{
 		return maxVelocity.x = MaxXVelocity;
 	}
-	
+
 	public var maxVelocityY(never, set):Float;
-	
+
 	private function set_maxVelocityY(MaxYVelocity:Float):Float
 	{
 		return maxVelocity.y = MaxYVelocity;
 	}
-	
+
 	override public function update():Void
 	{
 		if (lifespan > 0)
 		{
 			lifespan -= FlxG.elapsed;
-			
+
 			if (lifespan <= 0)
 			{
 				kill();
 			}
 		}
-		
+
 		if (FlxMath.pointInFlxRect(Math.floor(x), Math.floor(y), _weapon.bounds) == false)
 		{
 			kill();
 		}
-		
+
 		super.update();
 	}
 }

--- a/flixel/addons/weapon/FlxWeapon.hx
+++ b/flixel/addons/weapon/FlxWeapon.hx
@@ -1,28 +1,28 @@
 package flixel.addons.weapon;
 
-import flixel.FlxBasic;
-import flixel.FlxG;
-import flixel.FlxObject;
-import flixel.FlxSprite;
-import flixel.group.FlxTypedGroup;
-import flixel.system.FlxSound;
-import flixel.system.input.touch.FlxTouch;
-import flixel.tile.FlxTilemap;
-import flixel.util.FlxMisc;
-import flixel.util.FlxPoint;
-import flixel.util.FlxRect;
-import flixel.util.FlxVelocity;
+import org.flixel.FlxBasic;
+import org.flixel.FlxG;
+import org.flixel.FlxObject;
+import org.flixel.FlxSprite;
+import org.flixel.group.FlxTypedGroup;
+import org.flixel.system.FlxSound;
+import org.flixel.system.input.touch.FlxTouch;
+import org.flixel.tile.FlxTilemap;
+import org.flixel.util.FlxMisc;
+import org.flixel.util.FlxPoint;
+import org.flixel.util.FlxRect;
+import org.flixel.util.FlxVelocity;
 
 /**
  * A Weapon can only fire 1 type of bullet. But it can fire many of them at once (in different directions if needed) via createBulletPattern
  * A Player could fire multiple Weapons at the same time however, if you need to layer them up
- * 
+ *
  * @version 1.3 - October 9th 2011
  * @link http://www.photonstorm.com
  * @link http://www.haxeflixel.com
  * @author Richard Davey / Photon Storm
  * @author Touch added by Impaler / Beeblerox
- * 
+ *
  * TODO: Angled bullets
  * TODO: Baked Rotation support for angled bullets
  * TODO: Bullet death styles (particle effects)
@@ -31,7 +31,7 @@ import flixel.util.FlxVelocity;
  * TODO: Bullet uses random sprite from sprite sheet (for rainbow style bullets), or cycles through them in sequence?
  * TODO: Some Weapon base classes like shotgun, lazer, etc?
  */
-class FlxWeapon 
+class FlxWeapon
 {
 	// Quick firing direction angle constants
 	inline static public var BULLET_UP:Int = -90;
@@ -42,7 +42,7 @@ class FlxWeapon
 	inline static public var BULLET_NORTH_WEST:Int = -135;
 	inline static public var BULLET_SOUTH_EAST:Int = 45;
 	inline static public var BULLET_SOUTH_WEST:Int = 135;
-	
+
 	/**
 	 * Internal name for this weapon (i.e. "pulse rifle")
 	 */
@@ -51,43 +51,43 @@ class FlxWeapon
 	 * The FlxGroup into which all the bullets for this weapon are drawn. This should be added to your display and collision checked against it.
 	 */
 	public var group:FlxTypedGroup<FlxBullet>;
-	
+
 	// Internal variables, use with caution
 	public var nextFire:Int = 0;
 	public var fireRate:Int = 0;
 	public var bulletSpeed:Int;
-	
+
 	// Bullet values
 	public var bounds:FlxRect;
-	
+
 	public var parent:FlxSprite;
-	
+
 	public var multiShot:Int = 0;
 	public var bulletLifeSpan:Float = 0;
 	public var bulletDamage:Float = 1;
-	
+
 	public var bulletElasticity:Float = 0;
-	
+
 	public var rndFactorAngle:Int = 0;
 	public var rndFactorSpeed:Int = 0;
 	public var rndFactorLifeSpan:Float = 0;
 	public var rndFactorPosition:FlxPoint;
-	
+
 	/**
 	 * A reference to the Bullet that was fired
 	 */
 	public var currentBullet:FlxBullet;
-	
+
 	// Callbacks
 	public var onPreFireCallback:Void->Void;
 	public var onFireCallback:Void->Void;
 	public var onPostFireCallback:Void->Void;
-	
+
 	// Sounds
 	public var onPreFireSound:FlxSound;
 	public var onFireSound:FlxSound;
 	public var onPostFireSound:FlxSound;
-	
+
 	inline static private var FIRE:Int = 0;
 	inline static private var FIRE_AT_MOUSE:Int = 1;
 	inline static private var FIRE_AT_POSITION:Int = 2;
@@ -95,24 +95,24 @@ class FlxWeapon
 	inline static private var FIRE_FROM_ANGLE:Int = 4;
 	inline static private var FIRE_FROM_PARENT_ANGLE:Int = 5;
 	inline static private var FIRE_AT_TOUCH:Int = 6;
-	
+
 	private var _rotateToAngle:Bool;
 	private var _velocity:FlxPoint;
-	
+
 	// When firing from a fixed position (i.e. Missile Command)
 	private var _fireFromPosition:Bool;
 	private var _fireX:Int;
 	private var _fireY:Int;
-	
+
 	private var _lastFired:Int = 0;
 	private var _touchTarget:FlxTouch;
-	
+
 	//	When firing from a parent sprites position (i.e. Space Invaders)
 	private var _fireFromParent:Bool;
 	private var _positionOffset:FlxPoint;
 	private var _directionFromParent:Bool;
 	private var _angleFromParent:Bool;
-	
+
 	// TODO :)
 	/**
 	 * Keeps a tally of how many bullets have been fired by this weapon
@@ -124,15 +124,15 @@ class FlxWeapon
 	private var _bulletsPerMagazine:Int;
 	private var _magazineSwapDelay:Int;
 	private var _skipParentCollision:Bool;
-	
+
 	private var _magazineSwapCallback:Dynamic;
 	private var _magazineSwapSound:FlxSound;
-	
+
 	/**
 	 * Creates the FlxWeapon class which will fire your bullets.
 	 * You should call one of the makeBullet functions to visually create the bullets.
 	 * Then either use <code>setDirection</code> with <code>fire()</code> or one of the <code>fireAt</code> functions to launch them.
-	 * 
+	 *
 	 * @param	Name		The name of your weapon (i.e. "lazer" or "shotgun"). For your internal reference really, but could be displayed in-game.
 	 * @param	ParentRef	If this weapon belongs to a parent sprite, specify it here (bullets will fire from the sprites x/y vars as defined below).
 	 */
@@ -142,18 +142,18 @@ class FlxWeapon
 		bounds = new FlxRect(0, 0, FlxG.width, FlxG.height);
 		_positionOffset = new FlxPoint();
 		_velocity = new FlxPoint();
-		
+
 		name = Name;
-		
+
 		if (ParentRef != null)
 		{
 			setParent(ParentRef);
 		}
 	}
-	
+
 	/**
 	 * Makes a pixel bullet sprite (rather than an image). You can set the width/height and color of the bullet.
-	 * 
+	 *
 	 * @param	Quantity	How many bullets do you need to make? This value should be high enough to cover all bullets you need on-screen *at once* plus probably a few extra spare!
 	 * @param	Width		The width (in pixels) of the bullets
 	 * @param	Height		The height (in pixels) of the bullets
@@ -164,21 +164,21 @@ class FlxWeapon
 	public function makePixelBullet(Quantity:Int, Width:Int = 2, Height:Int = 2, Color:Int = 0xffffffff, OffsetX:Int = 0, OffsetY:Int = 0):Void
 	{
 		group = new FlxTypedGroup<FlxBullet>(Quantity);
-		
+
 		for (b in 0...Quantity)
 		{
 			var tempBullet:FlxBullet = new FlxBullet(this, b);
 			tempBullet.makeGraphic(Width, Height, Color);
 			group.add(tempBullet);
 		}
-		
+
 		_positionOffset.x = OffsetX;
 		_positionOffset.y = OffsetY;
 	}
-	
+
 	/**
 	 * Makes a bullet sprite from the given image. It will use the width/height of the image.
-	 * 
+	 *
 	 * @param	Quantity		How many bullets do you need to make? This value should be high enough to cover all bullets you need on-screen *at once* plus probably a few extra spare!
 	 * @param	Image			The image used to create the bullet from
 	 * @param	OffsetX			When the bullet is fired if you need to offset it on the x axis, for example to line it up with the "nose" of a space ship, set the amount here (positive or negative)
@@ -192,13 +192,13 @@ class FlxWeapon
 	public function makeImageBullet(Quantity:Int, Image:Dynamic, OffsetX:Int = 0, OffsetY:Int = 0, AutoRotate:Bool = false, Rotations:Int = 16, Frame:Int = -1, AntiAliasing:Bool = false, AutoBuffer:Bool = false):Void
 	{
 		group = new FlxTypedGroup<FlxBullet>(Quantity);
-		
+
 		_rotateToAngle = AutoRotate;
-		
+
 		for (b in 0...Quantity)
 		{
 			var tempBullet:FlxBullet = new FlxBullet(this, b);
-			
+
 			#if flash
 			if (AutoRotate)
 			{
@@ -215,14 +215,14 @@ class FlxWeapon
 			#end
 			group.add(tempBullet);
 		}
-		
+
 		_positionOffset.x = OffsetX;
 		_positionOffset.y = OffsetY;
 	}
-	
+
 	/**
 	 * Makes an animated bullet from the image and frame data given.
-	 * 
+	 *
 	 * @param	Quantity		How many bullets do you need to make? This value should be high enough to cover all bullets you need on-screen *at once* plus probably a few extra spare!
 	 * @param	ImageSequence	The image used to created the animated bullet from
 	 * @param	FrameWidth		The width of each frame in the animation
@@ -236,24 +236,24 @@ class FlxWeapon
 	public function makeAnimatedBullet(Quantity:Int, ImageSequence:Dynamic, FrameWidth:Int, FrameHeight:Int, Frames:Array<Int>, FrameRate:Int, Looped:Bool, OffsetX:Int = 0, OffsetY:Int = 0):Void
 	{
 		group = new FlxTypedGroup<FlxBullet>(Quantity);
-		
+
 		for (b in 0...Quantity)
 		{
 			var tempBullet:FlxBullet = new FlxBullet(this, b);
-			
+
 			tempBullet.loadGraphic(ImageSequence, true, false, FrameWidth, FrameHeight);
 			tempBullet.addAnimation("fire", Frames, FrameRate, Looped);
-			
+
 			group.add(tempBullet);
 		}
-		
+
 		_positionOffset.x = OffsetX;
 		_positionOffset.y = OffsetY;
 	}
-	
+
 	/**
 	 * Internal function that handles the actual firing of the bullets
-	 * 
+	 *
 	 * @param	Method
 	 * @param	X
 	 * @param	Y
@@ -266,19 +266,19 @@ class FlxWeapon
 		{
 			return false;
 		}
-		
+
 		currentBullet = getFreeBullet();
-		
+
 		if (currentBullet == null)
 		{
 			return false;
 		}
-		
+
 		if (onPreFireCallback != null)
 		{
 			onPreFireCallback();
 		}
-		
+
 		if (onPreFireSound != null)
 		{
 			onPreFireSound.play();
@@ -287,13 +287,13 @@ class FlxWeapon
 		// Clear any velocity that may have been previously set from the pool
 		currentBullet.velocity.x = 0;
 		currentBullet.velocity.y = 0;
-		
+
 		_lastFired = FlxG.game.ticks;
 		nextFire = FlxG.game.ticks + Std.int(fireRate / FlxG.timeScale);
-		
+
 		var launchX:Float = _positionOffset.x;
 		var launchY:Float = _positionOffset.y;
-		
+
 		if (_fireFromParent)
 		{
 			launchX += parent.x;
@@ -304,12 +304,12 @@ class FlxWeapon
 			launchX += _fireX;
 			launchY += _fireY;
 		}
-		
+
 		if (_directionFromParent)
 		{
 			_velocity = FlxVelocity.velocityFromFacing(parent, bulletSpeed);
 		}
-		
+
 		// Faster (less CPU) to use this small if-else ladder than a switch statement
 		if (Method == FlxWeapon.FIRE)
 		{
@@ -348,31 +348,31 @@ class FlxWeapon
 		{
 			onPostFireCallback();
 		}
-		
+
 		if (onPostFireSound != null)
 		{
 			onPostFireSound.play();
 		}
-		
+
 		_bulletsFired++;
-		
+
 		return true;
 	}
-	
+
 	/**
 	 * Fires a bullet (if one is available). The bullet will be given the velocity defined in setBulletDirection and fired at the rate set in setFireRate.
-	 * 
+	 *
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
 	inline public function fire():Bool
 	{
 		return runFire(FlxWeapon.FIRE);
 	}
-	
+
 	#if !FLX_NO_MOUSE
 	/**
 	 * Fires a bullet (if one is available) at the mouse coordinates, using the speed set in setBulletSpeed and the rate set in setFireRate.
-	 * 
+	 *
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
 	inline public function fireAtMouse():Bool
@@ -380,40 +380,40 @@ class FlxWeapon
 		return runFire(FlxWeapon.FIRE_AT_MOUSE);
 	}
 	#end
-	
+
 	#if !FLX_NO_TOUCH
 	/**
 	 * Fires a bullet (if one is available) at the FlxTouch coordinates, using the speed set in setBulletSpeed and the rate set in setFireRate.
-	 * 
+	 *
 	 * @param	Touch	The FlxTouch object to fire at, if null use the first available one
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
 	public function fireAtTouch(?Touch:FlxTouch):Bool
 	{
-		if (Touch == null) 
+		if (Touch == null)
 		{
 			_touchTarget = FlxG.touches.getFirst();
-		} 
-		else 
+		}
+		else
 		{
 			_touchTarget = Touch;
 		}
-		
+
 		var fired = false;
-		
-		if (_touchTarget != null) 
+
+		if (_touchTarget != null)
 		{
 			fired = runFire(FlxWeapon.FIRE_AT_TOUCH);
 			_touchTarget = null;
 		}
-		
+
 		return fired;
 	}
 	#end
-	
+
 	/**
 	 * Fires a bullet (if one is available) at the given x/y coordinates, using the speed set in setBulletSpeed and the rate set in setFireRate.
-	 * 
+	 *
 	 * @param	X	The x coordinate (in game world pixels) to fire at
 	 * @param	Y	The y coordinate (in game world pixels) to fire at
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
@@ -422,10 +422,10 @@ class FlxWeapon
 	{
 		return runFire(FlxWeapon.FIRE_AT_POSITION, X, Y);
 	}
-	
+
 	/**
 	 * Fires a bullet (if one is available) at the given targets x/y coordinates, using the speed set in setBulletSpeed and the rate set in setFireRate.
-	 * 
+	 *
 	 * @param	Target	The FlxSprite you wish to fire the bullet at
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
@@ -433,10 +433,10 @@ class FlxWeapon
 	{
 		return runFire(FlxWeapon.FIRE_AT_TARGET, 0, 0, Target);
 	}
-	
+
 	/**
 	 * Fires a bullet (if one is available) based on the given angle
-	 * 
+	 *
 	 * @param	Angle	The angle (in degrees) calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
@@ -444,20 +444,20 @@ class FlxWeapon
 	{
 		return runFire(FlxWeapon.FIRE_FROM_ANGLE, 0, 0, null, Angle);
 	}
-	
+
 	/**
 	 * Fires a bullet (if one is available) based on the angle of the Weapons parent
-	 * 
+	 *
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
 	inline public function fireFromParentAngle():Bool
 	{
 		return runFire(FlxWeapon.FIRE_FROM_PARENT_ANGLE);
 	}
-	
+
 	/**
 	 * Causes the Weapon to fire from the parents x/y value, as seen in Space Invaders and most shoot-em-ups.
-	 * 
+	 *
 	 * @param	ParentRef		If this weapon belongs to a parent sprite, specify it here (bullets will fire from the sprites x/y vars as defined below).
 	 * @param	VariableX		The x axis variable of the parent to use when firing. Typically "x", but could be "screenX" or any public getter that exposes the x coordinate.
 	 * @param	VariableY		The y axis variable of the parent to use when firing. Typically "y", but could be "screenY" or any public getter that exposes the y coordinate.
@@ -470,20 +470,20 @@ class FlxWeapon
 		if (ParentRef != null)
 		{
 			_fireFromParent = true;
-			
+
 			parent = ParentRef;
-			
+
 			_positionOffset.x = OffsetX;
 			_positionOffset.y = OffsetY;
-			
+
 			_directionFromParent = UseDirection;
 		}
 	}
-	
+
 	/**
 	 * Causes the Weapon to fire from a fixed x/y position on the screen, like in the game Missile Command.<br>
 	 * If set this over-rides a call to setParent (which causes the Weapon to fire from the parents x/y position)
-	 * 
+	 *
 	 * @param	X			The x coordinate (in game world pixels) to fire from
 	 * @param	Y			The y coordinate (in game world pixels) to fire from
 	 * @param	OffsetX		When the bullet is fired if you need to offset it on the x axis, for example to line it up with the "nose" of a space ship, set the amount here (positive or negative)
@@ -494,59 +494,59 @@ class FlxWeapon
 		_fireFromPosition = true;
 		_fireX = X;
 		_fireY = Y;
-		
+
 		_positionOffset.x = OffsetX;
 		_positionOffset.y = OffsetY;
 	}
-	
+
 	/**
 	 * The speed in pixels/sec (sq) that the bullet travels at when fired via fireAtMouse, fireAtPosition or fireAtTarget.<br>
 	 * You can update this value in real-time, should you need to speed-up or slow-down your bullets (i.e. collecting a power-up)
-	 * 
+	 *
 	 * @param	Speed	The speed it will move, in pixels per second (sq)
 	 */
 	public function setBulletSpeed(Speed:Int):Void
 	{
 		bulletSpeed = Speed;
 	}
-	
+
 	/**
 	 * The speed in pixels/sec (sq) that the bullet travels at when fired via fireAtMouse, fireAtPosition or fireAtTarget.
-	 * 
+	 *
 	 * @return	The speed the bullet moves at, in pixels per second (sq)
 	 */
 	public function getBulletSpeed():Int
 	{
 		return bulletSpeed;
 	}
-	
+
 	/**
 	 * Sets the firing rate of the Weapon. By default there is no rate, as it can be controlled by FlxControl.setFireButton.<br>
 	 * However if you are firing using the mouse you may wish to set a firing rate.
-	 * 
+	 *
 	 * @param	Rate	The delay in milliseconds (ms) between which each bullet is fired, set to zero to clear
 	 */
 	public function setFireRate(Rate:Int):Void
 	{
 		fireRate = Rate;
 	}
-	
+
 	/**
 	 * When a bullet goes outside of this bounds it will be automatically killed, freeing it up for firing again.
 	 * TODO - Needs testing with a scrolling map (when not using single screen display)
-	 * 
+	 *
 	 * @param	Bounds	An FlxRect area. Inside this area the bullet should be considered alive, once outside it will be killed.
 	 */
 	public function setBulletBounds(Bounds:FlxRect):Void
 	{
 		bounds = Bounds;
 	}
-	
+
 	/**
 	 * Set the direction the bullet will travel when fired.<br>
 	 * You can use one of the consts such as BULLET_UP, BULLET_DOWN or BULLET_NORTH_EAST to set the angle easily.<br>
 	 * Speed should be given in pixels/sec (sq) and is the speed at which the bullet travels when fired.
-	 * 
+	 *
 	 * @param	angle		The angle of the bullet. In clockwise positive direction: Right = 0, Down = 90, Left = 180, Up = -90. You can use one of the consts such as BULLET_UP, etc
 	 * @param	speed		The speed it will move, in pixels per second (sq)
 	 */
@@ -554,11 +554,11 @@ class FlxWeapon
 	{
 		_velocity = FlxVelocity.velocityFromAngle(Angle, Speed);
 	}
-	
+
 	/**
 	 * Sets gravity on all currently created bullets<br>
 	 * This will update ALL bullets, even those currently "in flight", so be careful about when you call this!
-	 * 
+	 *
 	 * @param	ForceX	A positive value applies gravity dragging the bullet to the right. A negative value drags the bullet to the left. Zero disables horizontal gravity.
 	 * @param	ForceY	A positive value applies gravity dragging the bullet down. A negative value drags the bullet up. Zero disables vertical gravity.
 	 */
@@ -567,12 +567,12 @@ class FlxWeapon
 		group.setAll("xGravity", ForceX);
 		group.setAll("yGravity", ForceY);
 	}
-	
+
 	/**
 	 * If you'd like your bullets to accelerate to their top speed rather than be launched already at it, then set the acceleration value here.<br>
 	 * If you've previously set the acceleration then setting it to zero will cancel the effect.<br>
 	 * This will update ALL bullets, even those currently "in flight", so be careful about when you call this!
-	 * 
+	 *
 	 * @param	AccelerationX		Acceleration speed in pixels per second to apply to the sprites horizontal movement, set to zero to cancel. Negative values move left, positive move right.
 	 * @param	AccelerationY		Acceleration speed in pixels per second to apply to the sprites vertical movement, set to zero to cancel. Negative values move up, positive move down.
 	 * @param	SpeedMaxX			The maximum speed in pixels per second in which the sprite can move horizontally
@@ -593,12 +593,12 @@ class FlxWeapon
 			group.setAll("maxVelocityY", SpeedMaxY);
 		}
 	}
-	
+
 	/**
 	 * When the bullet is fired from a parent (or fixed position) it will do so from their x/y coordinate.<br>
 	 * Often you need to align a bullet with the sprite, i.e. to make it look like it came out of the "nose" of a space ship.<br>
 	 * Use this offset x/y value to achieve that effect.
-	 * 
+	 *
 	 * @param	OffsetX		The x coordinate offset to add to the launch location (positive or negative)
 	 * @param	OffsetY		The y coordinate offset to add to the launch location (positive or negative)
 	 */
@@ -607,10 +607,10 @@ class FlxWeapon
 		_positionOffset.x = OffsetX;
 		_positionOffset.y = OffsetY;
 	}
-	
+
 	/**
 	 * To make the bullet apply a random factor to either its angle, speed, or both when fired, set these values. Can create a nice "scatter gun" effect.
-	 * 
+	 *
 	 * @param 	RandomAngle		The +- value applied to the angle when fired. For example 20 means the bullet can fire up to 20 degrees under or over its angle when fired.
 	 * @param	RandomSpeed		The +- value applied to the speed when fired. For example 20 means the bullet can fire up to 20 px/sec slower or faster when fired.
 	 * @param 	RandomPosition  The +- value applied to the firing location when fired (fire spread).
@@ -620,70 +620,70 @@ class FlxWeapon
 	{
 		rndFactorAngle = RandomAngle;
 		rndFactorSpeed = RandomSpeed;
-		
+
 		if (RandomPosition != null)
 		{
 			rndFactorPosition = RandomPosition;
 		}
-		
+
 		rndFactorLifeSpan = (RandomLifeSpan < 0) ? -RandomLifeSpan : RandomLifeSpan;
 	}
-	
+
 	/**
 	 * If the bullet should have a fixed life span use this function to set it.
 	 * The bullet will be killed once it passes this lifespan, if still alive and in bounds.
-	 * 
+	 *
 	 * @param	Lifespan  The lifespan of the bullet, given in seconds.
 	 */
 	public function setBulletLifeSpan(Lifespan:Float):Void
 	{
 		bulletLifeSpan = Lifespan;
 	}
-	
+
 	/**
 	 * The elasticity of the fired bullet controls how much it rebounds off collision surfaces.
-	 * 
+	 *
 	 * @param	Elasticity	The elasticity of the bullet between 0 and 1 (0 being no rebound, 1 being 100% force rebound). Set to zero to disable.
 	 */
 	public function setBulletElasticity(Elasticity:Float):Void
 	{
 		bulletElasticity = Elasticity;
 	}
-	
+
 	/**
 	 * Internal function that returns the next available bullet from the pool (if any)
-	 * 
+	 *
 	 * @return	A <code>FlxBullet</code>
 	 */
 	private function getFreeBullet():FlxBullet
 	{
 		var result:FlxBullet = null;
-		
+
 		if (group == null || group.length == 0)
 		{
 			throw "Weapon.as cannot fire a bullet until one has been created via a call to makePixelBullet or makeImageBullet";
 			return null;
 		}
-		
+
 		var bullet:FlxBullet;
-		
+
 		for (i in 0...(group.members.length))
 		{
 			bullet = group.members[i];
-			
+
 			if (bullet.exists == false)
 			{
 				result = bullet;
 				break;
 			}
 		}
-		
+
 		return result;
 	}
-	
+
 	/**
 	 * Sets a pre-fire callback function and sound. These are played immediately before the bullet is fired.
-	 * 
+	 *
 	 * @param	Callback	The function to call
 	 * @param	Sound		A FlxSound to play
 	 */
@@ -692,10 +692,10 @@ class FlxWeapon
 		onPreFireCallback = Callback;
 		onPreFireSound = Sound;
 	}
-	
+
 	/**
 	 * Sets a fire callback function and sound. These are played immediately as the bullet is fired.
-	 * 
+	 *
 	 * @param	Callback	The function to call
 	 * @param	Sound		A FlxSound to play
 	 */
@@ -704,10 +704,10 @@ class FlxWeapon
 		onFireCallback = Callback;
 		onFireSound = Sound;
 	}
-	
+
 	/**
 	 * Sets a post-fire callback function and sound. These are played immediately after the bullet is fired.
-	 * 
+	 *
 	 * @param	Callback	The function to call
 	 * @param	Sound		An FlxSound to play
 	 */
@@ -716,10 +716,10 @@ class FlxWeapon
 		onPostFireCallback = Callback;
 		onPostFireSound = Sound;
 	}
-	
+
 	/**
 	 * Checks to see if the bullets are overlapping the specified object or group
-	 * 
+	 *
 	 * @param  ObjectOrGroup  	The group or object to check if bullets collide
 	 * @param  NotifyCallBack  	A function that will get called if a bullet overlaps an object
 	 * @param  SkipParent    	Don't trigger colision notifies with the parent of this object
@@ -739,7 +739,7 @@ class FlxWeapon
 		{
 			return false;
 		}
-		
+
 		if (Std.is(Object, FlxTilemap))
 		{
 			return cast(Object, FlxTilemap).overlapsWithCallback(Bullet);
@@ -754,13 +754,13 @@ class FlxWeapon
 	{
 		Bullet.kill();
 	}
-	
+
 	// TODO
 	public function createBulletPattern(Pattern:Array<Dynamic>):Void
 	{
 		//	Launches this many bullets
 	}
-	
+
 	public function update():Void
 	{
 		// ???


### PR DESCRIPTION
While working with the Tiled demo, I was getting a lot of "class not found errors" because the imports for flixel packages were missing the "org."

Unsure if this is because of a recent restructuring of the lib, or project-specific search path configuration, but I think having the full path in there should mean this code will be more portable.

Sorry about the boat-load of whitespace changes. My editor was configured to strip trailing whitespace on save (and I didn't think to disable that feature).
