### PR TITLE
Allow FlxWeapon to use a specified class of bullet (must inherit FlxBull...

### DIFF
--- a/flixel/addons/weapon/FlxWeapon.hx
+++ b/flixel/addons/weapon/FlxWeapon.hx
@@ -147,6 +147,8 @@ class FlxWeapon
 	 * 
 	 * @param	Name		The name of your weapon (i.e. "lazer" or "shotgun"). For your internal reference really, but could be displayed in-game.
 	 * @param	ParentRef	If this weapon belongs to a parent sprite, specify it here (bullets will fire from the sprites x/y vars as defined below).
+	 * @param	BulletType	Class of the bullet to be associated with this FlxWeapon, must inherit FlxBullet
+	 * @param	BulletID	An optional ID for the bullet. Can be accessed through FlxBullet.ID
 	 */
 	public function new(Name:String, ?ParentRef:FlxSprite, ?BulletType:Class<FlxBullet>, ?BulletID:Int = 0)
 	{


### PR DESCRIPTION
...et).

Added BulletID parameter to identify the type of bullet. (Useful in collsion callbacks).
