### PR TITLE
Making setFontGraphics Public

### DIFF
--- a/flixel/addons/text/FlxBitmapFont.hx
+++ b/flixel/addons/text/FlxBitmapFont.hx
@@ -177,7 +177,7 @@ class FlxBitmapFont extends FlxSprite
 		#end
 	}
 	
-	private function setFontGraphics(value:CachedGraphics):Void
+	public function setFontGraphics(value:CachedGraphics):Void
 	{
 		if (_fontSet != null && _fontSet != value)
 		{


### PR DESCRIPTION
Changed setFontGraphics to Public so that it is easier to access. Used to set the graphics used in the bitmap font. Great if you need to change the color or style.
