### PR TITLE
[+] skipping windows newlines (0x0d 0x0a) while base64 parsing

### DIFF
--- a/flixel/addons/editors/tiled/TiledLayer.hx
+++ b/flixel/addons/editors/tiled/TiledLayer.hx
@@ -112,7 +112,7 @@ class TiledLayer
 		while (i < data.length - 3)
 		{
 			// Ignore whitespace
-			if (data.charAt(i) == " " || data.charAt(i) == "\n")
+			if (data.charAt(i) == " " || data.charAt(i) == "\n" || data.charAt(i) == "\r")
 			{
 				i++; continue;
 			}


### PR DESCRIPTION
Fix for issue #18
