### PR TITLE
removed useless class field

### DIFF
--- a/flixel/addons/ui/FlxButtonPlus.hx
+++ b/flixel/addons/ui/FlxButtonPlus.hx
@@ -68,10 +68,6 @@ class FlxButtonPlus extends FlxSpriteGroup
 	 */
 	private var _status:Int;
 	/**
-	 * Tracks whether or not the button is currently pressed.
-	 */
-	private var _pressed:Bool;
-	/**
 	 * Whether or not the button has initialized itself yet.
 	 */
 	private var _initialized:Bool;
@@ -141,7 +137,6 @@ class FlxButtonPlus extends FlxSpriteGroup
 		}
 
 		_status = NORMAL;
-		_pressed = false;
 		_initialized = false;
 	}
 	
@@ -158,7 +153,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 		buttonNormal.pixels = Normal.pixels;
 		buttonHighlight.pixels = Highlight.pixels;
 
-		if (_pressed)
+		if (_status==HIGHLIGHT)
 		{
 			buttonNormal.visible = false;
 		}


### PR DESCRIPTION
_pressed was only ever set in new() to false and later never changed. besides that it is not needed in the class anyway so it was removed.
