### PR TITLE
FlxButtonPlus: change type of X and Y arguments to Float

### DIFF
--- a/flixel/addons/ui/FlxButtonPlus.hx
+++ b/flixel/addons/ui/FlxButtonPlus.hx
@@ -87,7 +87,7 @@ class FlxButtonPlus extends FlxSpriteGroup
 	 * @param	Width		The width of the button.
 	 * @param	Height		The height of the button.
 	 */
-	public function new(X:Int = 0, Y:Int = 0, ?Callback:Void->Void, ?Label:String, Width:Int = 100, Height:Int = 20)
+	public function new(X:Float = 0, Y:Float = 0, ?Callback:Void->Void, ?Label:String, Width:Int = 100, Height:Int = 20)
 	{
 		offColor = [0xff008000, 0xff00ff00];
 		onColor = [0xff800000, 0xffff0000];


### PR DESCRIPTION
X and Y are float everywhere else. Especially in FlxObject, from where FlxButtonPlus inherits them (indirectly)
