### PR TITLE
Screengrab specify directory cpp

### DIFF
--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -162,19 +162,28 @@ class FlxScreenGrab extends FlxPlugin
 		#else
 		var png:ByteArray = screenshot.bitmapData.encode('x');
 		var path:String = "";
+		var documentsDirectory = "";
+		var saveFile:Dynamic=null;
 		try
 		{
-			path = Dialogs.saveFile("", "", flash.filesystem.File.documentsDirectory.nativePath);
-			//these parameters can be added when systools is finally updated on haxelib:
-			//, { count:1, descriptions:["png files"], extensions:["*.png"] } );
+			documentsDirectory = flash.filesystem.File.documentsDirectory.nativePath;
+			#if (systools <= 1)
+				path = Dialogs.saveFile("", "", documentsDirectory);
+			#else
+				path = Dialogs.saveFile("", "", "", { count:1, descriptions:["png files"], extensions:["*.png"] } );
+			#end
 		}
 		catch (msg:String)
 		{
-			path = Filename;
+			path = Filename;			//if there was an error write out to default directory (game install directory)
 		}
-		var f = sys.io.File.write(path, true);
-		f.writeString(png.readUTFBytes(png.length));
-		f.close();
+		
+		if (path != "" && path != null)	//if path is empty, the user cancelled the save operation and we can safely do nothing
+		{
+			var f = sys.io.File.write(path, true);
+			f.writeString(png.readUTFBytes(png.length));
+			f.close();
+		}
 		#end
 	}
 	


### PR DESCRIPTION
On cpp target, lets you specify where the screengrab should go, rather than just silently writing it to some obscure location. (Mirrors the flash behavior).

Adds dependency for systools.Dialogs, perhaps that needs to be reflected in the haxelib metadata? I'm not 100% sure how that all works.
