### PR TITLE
Small edit to FlxTrailArea.hx to fix offset sprites having incorrect trails.

### DIFF
--- a/flixel/addons/effects/FlxTrailArea.hx
+++ b/flixel/addons/effects/FlxTrailArea.hx
@@ -201,7 +201,7 @@ class FlxTrailArea extends FlxSprite
 							}
 							_matrix.translate((member.origin.x), (member.origin.y));
 						}
-						_matrix.translate(member.x - x, member.y - y);
+						_matrix.translate(member.x - x - member.offset.x, member.y - y - member.offset.y);
 						framePixels.draw(member.getFlxFrameBitmapData(), _matrix, member.colorTransform, blendMode, null, antialiasing);
 					}
 					


### PR DESCRIPTION
If a sprite had an offset, the trail would show up with the sprite's trail being offset further by the same amount. This commit fixes that.
