### PR TITLE
Update for HaxeFlixel/flixel#1263

### DIFF
--- a/flixel/addons/display/shapes/FlxShape.hx
+++ b/flixel/addons/display/shapes/FlxShape.hx
@@ -1,13 +1,11 @@
 package flixel.addons.display.shapes;
 
 import flash.display.BlendMode;
-import flash.display.Shape;
 import flash.geom.Matrix;
 import flixel.FlxSprite;
 import flixel.util.FlxColor;
-import flixel.util.FlxSpriteUtil.FillStyle;
-import flixel.util.FlxSpriteUtil.LineStyle;
 import flixel.util.FlxSpriteUtil.DrawStyle;
+import flixel.util.FlxSpriteUtil.LineStyle;
 
 /**
  * A convenience class for wrapping vector shape drawing in FlxSprites, all ready to go.
@@ -17,7 +15,7 @@ import flixel.util.FlxSpriteUtil.DrawStyle;
 class FlxShape extends FlxSprite
 {
 	public var lineStyle(default, set):LineStyle;		//stroke settings
-	public var fillStyle(default, set):FillStyle;		//fill settings
+	public var fillColor(default, set):FlxColor;		//fill color, FlxColor.TRANSPARENT means no fill
 	
 	public var shape_id:String;						//string id of the shape
 	public var shapeDirty:Bool = false;				//flag to flip to force it to redraw the shape
@@ -33,11 +31,11 @@ class FlxShape extends FlxSprite
 	 * @param	CanvasWidth		Width of pixel canvas
 	 * @param	CanvasHeight	Height of pixel canvas
 	 * @param	LineStyle_		Drawing style for strokes -- see flixel.util.FlxSpriteUtil.LineStyle
-	 * @param	FillStyle_		Drawing style for fills -- see flixel.util.FlxSpriteUtil.FillStyle
+	 * @param	FillColor		Color of the fill. FlxColor.TRANSPARENT means no fill.
 	 * @param	TrueWidth		Width of raw unstyled geometric object, ignoring line thickness, filters, etc
 	 * @param	TrueHeight		Height of raw unstyled geometric object, ignoring line thickness, filters, etc
 	 */
-	public function new(X:Float, Y:Float, CanvasWidth:Float, CanvasHeight:Float, LineStyle_:LineStyle, FillStyle_:FillStyle, TrueWidth:Float=0, TrueHeight:Float=0) 
+	public function new(X:Float, Y:Float, CanvasWidth:Float, CanvasHeight:Float, LineStyle_:LineStyle, FillColor:FlxColor, TrueWidth:Float=0, TrueHeight:Float=0) 
 	{
 		super(X, Y);
 		
@@ -52,7 +50,7 @@ class FlxShape extends FlxSprite
 		makeGraphic(Std.int(width), Std.int(height), FlxColor.TRANSPARENT, true);
 		
 		lineStyle = LineStyle_;
-		fillStyle = FillStyle_;
+		fillColor = FillColor;
 		
 		//we'll eventually want a public drawStyle parameter, but we'll also need an internval _drawStyle to do 
 		//some specific tricks for various shapes (special matrices, punching holes in Donut shapes by using ERASE blend mode, etc)
@@ -70,7 +68,6 @@ class FlxShape extends FlxSprite
 	override public function destroy():Void 
 	{
 		lineStyle = null;
-		fillStyle = null;
 		super.destroy();
 	}
 	
@@ -129,11 +126,11 @@ class FlxShape extends FlxSprite
 		return lineStyle;
 	}
 	
-	private inline function set_fillStyle(fs:FillStyle):FillStyle 
+	private inline function set_fillColor(fc:FlxColor):FlxColor 
 	{
-		fillStyle = fs;
+		fillColor = fc;
 		shapeDirty = true;
-		return fillStyle;
+		return fillColor;
 	}
 	
 	private function getStrokeOffsetMatrix(matrix:Matrix):Matrix

--- a/flixel/addons/display/shapes/FlxShapeBox.hx
+++ b/flixel/addons/display/shapes/FlxShapeBox.hx
@@ -3,6 +3,7 @@ package flixel.addons.display.shapes;
 import flash.display.BitmapData;
 import flash.display.Shape;
 import flash.geom.Matrix;
+import flixel.util.FlxColor;
 import flixel.util.FlxSpriteUtil;
 import flixel.util.FlxSpriteUtil.LineStyle;
 
@@ -16,7 +17,7 @@ class FlxShapeBox extends FlxShape
 	 * Creates a FlxSprite with a circle drawn on top of it. 
 	 * X/Y is where the SPRITE is, the circle's upper-left
 	 */
-	public function new(X:Float, Y:Float, W:Float, H:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, W:Float, H:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		shape_id = "box";
 		
@@ -32,12 +33,12 @@ class FlxShapeBox extends FlxShape
 		if (h <= 0) 
 			h = strokeBuffer;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_, shapeWidth, shapeHeight);
+		super(X, Y, w, h, LineStyle_, FillColor, shapeWidth, shapeHeight);
 	}
 	
 	override public function drawSpecificShape(?matrix:Matrix):Void 
 	{
-		FlxSpriteUtil.drawRect(this, lineStyle.thickness/2, lineStyle.thickness/2, shapeWidth, shapeHeight, fillStyle.color, lineStyle);
+		FlxSpriteUtil.drawRect(this, lineStyle.thickness/2, lineStyle.thickness/2, shapeWidth, shapeHeight, fillColor, lineStyle);
 	}
 	
 	private inline function set_shapeWidth(f:Float):Float

--- a/flixel/addons/display/shapes/FlxShapeCircle.hx
+++ b/flixel/addons/display/shapes/FlxShapeCircle.hx
@@ -1,6 +1,7 @@
 package flixel.addons.display.shapes;
 
 import flash.geom.Matrix;
+import flixel.util.FlxColor;
 import flixel.util.FlxSpriteUtil;
 
 class FlxShapeCircle extends FlxShape 
@@ -11,7 +12,7 @@ class FlxShapeCircle extends FlxShape
 	 * Creates a FlxSprite with a circle drawn on top of it. 
 	 * X/Y is where the SPRITE is, the circle's upper-left
 	 */
-	public function new(X:Float, Y:Float, Radius:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, Radius:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		shape_id = "circle";
 		
@@ -30,12 +31,12 @@ class FlxShapeCircle extends FlxShape
 		if (h <= 0) 
 			h = strokeBuffer;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_, trueWidth, trueHeight);
+		super(X, Y, w, h, LineStyle_, FillColor, trueWidth, trueHeight);
 	}
 	
 	override public inline function drawSpecificShape(?matrix:Matrix):Void 
 	{
-		FlxSpriteUtil.drawCircle(this, Math.ceil(width / 2), Math.ceil(height / 2), radius, fillStyle.color, lineStyle, { matrix: matrix });
+		FlxSpriteUtil.drawCircle(this, Math.ceil(width / 2), Math.ceil(height / 2), radius, fillColor, lineStyle, { matrix: matrix });
 	}
 	
 	private inline function set_radius(r:Float):Float

--- a/flixel/addons/display/shapes/FlxShapeCross.hx
+++ b/flixel/addons/display/shapes/FlxShapeCross.hx
@@ -30,7 +30,7 @@ class FlxShapeCross extends FlxShape
 	
 	private var vertices:Array<FlxPoint>;
 	
-	public function new(X:Float, Y:Float, HLength:Float, HSize:Float, VLength:Float, VSize:Float, IntersectionH:Float, IntersectionV:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, HLength:Float, HSize:Float, VLength:Float, VSize:Float, IntersectionH:Float, IntersectionV:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		shape_id = "cross";
 		
@@ -51,7 +51,7 @@ class FlxShapeCross extends FlxShape
 		if (h <= 0) 
 			h = strokeBuffer;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_, horizontalLength, verticalLength);
+		super(X, Y, w, h, LineStyle_, FillColor, horizontalLength, verticalLength);
 	}
 	
 	public override function destroy():Void 
@@ -132,7 +132,7 @@ class FlxShapeCross extends FlxShape
 		_matrix.identity();
 		_matrix.translate(lineStyle.thickness / 2, lineStyle.thickness / 2);
 		
-		FlxSpriteUtil.drawPolygon(this, vertices, fillStyle.color, lineStyle, fillStyle, { matrix: _matrix });
+		FlxSpriteUtil.drawPolygon(this, vertices, fillColor, lineStyle, { matrix: _matrix });
 		
 		fixBoundaries(horizontalLength, verticalLength);
 	}

--- a/flixel/addons/display/shapes/FlxShapeDonut.hx
+++ b/flixel/addons/display/shapes/FlxShapeDonut.hx
@@ -17,7 +17,7 @@ class FlxShapeDonut extends FlxShape
 	 * Creates a FlxSprite with a donut drawn on top of it. 
 	 * X/Y is where the SPRITE is, the donut's upper-left
 	 */
-	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		shape_id = "donut";
 		
@@ -37,14 +37,14 @@ class FlxShapeDonut extends FlxShape
 		if (h <= 0) 
 			h = strokeBuffer;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_, trueWidth, trueHeight);
+		super(X, Y, w, h, LineStyle_, FillColor, trueWidth, trueHeight);
 	}
 	
 	override public function drawSpecificShape(?matrix:Matrix):Void 
 	{
 		var cx:Float = Math.ceil(width / 2);
 		var cy:Float = Math.ceil(height / 2);
-		FlxSpriteUtil.drawCircle(this, cx, cy, radius_out, fillStyle.color, lineStyle, { matrix: matrix } );
+		FlxSpriteUtil.drawCircle(this, cx, cy, radius_out, fillColor, lineStyle, { matrix: matrix } );
 		
 		if (radius_in > 0) 
 			FlxSpriteUtil.drawCircle(this, cx, cy, radius_in, FlxColor.RED, null, { matrix: matrix, blendMode: BlendMode.ERASE, smoothing: true });

--- a/flixel/addons/display/shapes/FlxShapeDoubleCircle.hx
+++ b/flixel/addons/display/shapes/FlxShapeDoubleCircle.hx
@@ -1,6 +1,7 @@
 package flixel.addons.display.shapes;
 
 import flash.geom.Matrix;
+import flixel.util.FlxColor;
 import flixel.util.FlxSpriteUtil;
 
 class FlxShapeDoubleCircle extends FlxShapeDonut
@@ -9,16 +10,16 @@ class FlxShapeDoubleCircle extends FlxShapeDonut
 	 * Creates a FlxSprite with a double-circle drawn on top of it. 
 	 * X/Y is where the SPRITE is, the double-circle's upper-left
 	 */
-	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
-		super(X, Y, RadiusOut, RadiusIn, LineStyle_, FillStyle_);
+		super(X, Y, RadiusOut, RadiusIn, LineStyle_, FillColor);
 	}
 	
 	override public function drawSpecificShape(?matrix:Matrix):Void 
 	{
 		var cx:Float = Math.ceil(width / 2);
 		var cy:Float = Math.ceil(height / 2);
-		FlxSpriteUtil.drawCircle(this, cx, cy, radius_out, fillStyle.color, lineStyle,  { matrix: matrix });
+		FlxSpriteUtil.drawCircle(this, cx, cy, radius_out, fillColor, lineStyle,  { matrix: matrix });
 		FlxSpriteUtil.drawCircle(this, cx, cy, radius_in, 0x00000000, lineStyle,  { matrix: matrix });
 	}
 }

--- a/flixel/addons/display/shapes/FlxShapeGrid.hx
+++ b/flixel/addons/display/shapes/FlxShapeGrid.hx
@@ -1,6 +1,7 @@
 package flixel.addons.display.shapes;
 
 import flash.geom.Matrix;
+import flixel.util.FlxColor;
 import flixel.util.FlxSpriteUtil;
 
 class FlxShapeGrid extends FlxShapeBox
@@ -14,7 +15,7 @@ class FlxShapeGrid extends FlxShapeBox
 	 * Creates a FlxSprite with a grid drawn on top of it. 
 	 * X/Y is where the SPRITE is, the grid upper-left
 	 */
-	public function new(X:Float, Y:Float, CellWidth:Float, CellHeight:Float, CellsWide:Int, CellsTall:Int, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, CellWidth:Float, CellHeight:Float, CellsWide:Int, CellsTall:Int, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		var w:Float = CellWidth * CellsWide;
 		var h:Float = CellHeight * CellsTall;
@@ -24,7 +25,7 @@ class FlxShapeGrid extends FlxShapeBox
 		cellWidth = CellWidth;
 		cellHeight = CellHeight;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_);
+		super(X, Y, w, h, LineStyle_, FillColor);
 	}
 	
 	override public function drawSpecificShape(?matrix:Matrix):Void 
@@ -33,7 +34,7 @@ class FlxShapeGrid extends FlxShapeBox
 		var oy:Float = (lineStyle.thickness / 2);
 		
 		//draw the fill
-		FlxSpriteUtil.drawRect(this, ox, oy, shapeWidth, shapeHeight, fillStyle.color, null);
+		FlxSpriteUtil.drawRect(this, ox, oy, shapeWidth, shapeHeight, fillColor);
 		
 		//draw vertical lines
 		for (iw in 0...cellsWide+1)

--- a/flixel/addons/display/shapes/FlxShapeLightning.hx
+++ b/flixel/addons/display/shapes/FlxShapeLightning.hx
@@ -177,7 +177,6 @@ class FlxShapeLightning extends FlxShapeLine
 			FlxSpriteUtil.drawLine(this, l.a.x+dw, l.a.y+dh, l.b.x+dw, l.b.y+dh, lineStyle);
 		
 		//lineStyle.thickness = 1;
-		var fillStyle:FillStyle = { hasFill:false };
 		
 		width = trueWidth;
 		height = trueHeight;

--- a/flixel/addons/display/shapes/FlxShapeSquareDonut.hx
+++ b/flixel/addons/display/shapes/FlxShapeSquareDonut.hx
@@ -1,8 +1,6 @@
 package flixel.addons.display.shapes;
 
-import flash.display.BitmapData;
 import flash.display.BlendMode;
-import flash.display.Shape;
 import flash.geom.Matrix;
 import flixel.util.FlxColor;
 import flixel.util.FlxSpriteUtil;
@@ -16,7 +14,7 @@ class FlxShapeSquareDonut extends FlxShape
 	 * Creates a FlxSprite with a square donut drawn on top of it. 
 	 * X/Y is where the SPRITE is, the square's upper-left
 	 */
-	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillStyle_:FillStyle) 
+	public function new(X:Float, Y:Float, RadiusOut:Float, RadiusIn:Float, LineStyle_:LineStyle, FillColor:FlxColor) 
 	{
 		shape_id = "square_donut";
 		
@@ -36,7 +34,7 @@ class FlxShapeSquareDonut extends FlxShape
 		if (h <= 0) 
 			h = strokeBuffer;
 		
-		super(X, Y, w, h, LineStyle_, FillStyle_, trueWidth, trueHeight);
+		super(X, Y, w, h, LineStyle_, FillColor, trueWidth, trueHeight);
 	}
 	
 	override public function drawSpecificShape(?matrix:Matrix):Void 
@@ -44,11 +42,11 @@ class FlxShapeSquareDonut extends FlxShape
 		var cx:Float = Math.ceil(width / 2);
 		var cy:Float = Math.ceil(height / 2);
 		
-		FlxSpriteUtil.drawRect(this, 0, 0, radius_out * 2, radius_out * 2, fillStyle.color, lineStyle, fillStyle, { matrix: matrix });
+		FlxSpriteUtil.drawRect(this, 0, 0, radius_out * 2, radius_out * 2, fillColor, lineStyle, { matrix: matrix });
 		if (radius_in > 0) {
-			FlxSpriteUtil.drawRect(this, (radius_out - radius_in), (radius_out - radius_in), radius_in * 2, radius_in * 2, FlxColor.RED, null, fillStyle, { matrix: matrix, blendMode: BlendMode.ERASE, smoothing: true});
+			FlxSpriteUtil.drawRect(this, (radius_out - radius_in), (radius_out - radius_in), radius_in * 2, radius_in * 2, FlxColor.RED, null, { matrix: matrix, blendMode: BlendMode.ERASE, smoothing: true});
 		}
-		FlxSpriteUtil.drawRect(this, (radius_out - radius_in), (radius_out - radius_in), radius_in * 2, radius_in * 2, FlxColor.TRANSPARENT, lineStyle, null, { matrix: matrix });
+		FlxSpriteUtil.drawRect(this, (radius_out - radius_in), (radius_out - radius_in), radius_in * 2, radius_in * 2, FlxColor.TRANSPARENT, lineStyle, { matrix: matrix });
 	}
 	
 	private inline function set_radius_out(r:Float):Float


### PR DESCRIPTION
Update for HaxeFlixel/flixel#1263 if it gets accepted.  Removed all fill styles and replaced them with `FillColor:FlxColor` for `FlxSpriteUtil` functions.
