### PR TITLE
Fixed visual glitch with switch-state transitions

### DIFF
--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -84,6 +84,7 @@ class FlxTransitionableState extends FlxState
 	override public function transitionToState(Next:FlxState):Void
 	{
 		//play the exit transition, and when it's done call FlxG.switchState
+		_exiting = true;
 		transitionOut(
 			function():Void
 			{
@@ -133,6 +134,7 @@ class FlxTransitionableState extends FlxState
 	
 	private var transOutFinished:Bool = false;
 	
+	private var _exiting:Bool = false;
 	private var _onExit:Void->Void;
 	
 	private function get_hasTransIn():Bool
@@ -163,7 +165,12 @@ class FlxTransitionableState extends FlxState
 	private function finishTransOut()
 	{
 		transOutFinished = true;
-		closeSubState();
+		
+		if (!_exiting)
+		{
+			closeSubState();
+		}
+		
 		if (_onExit != null)
 		{
 			_onExit();


### PR DESCRIPTION
Fixes a glitch where a state-transition results in a visual gap after the out transition has played but before the new state is loaded.

This solution distinguishes between two circumstances:
1. A same-state transition (must close substate)
2. A between-state transition (must keep substate open until switch state process closes it)

Rather than stick some sort of conditional parameter in transitionOut(), we instead set a flag in transitionToState(), which is then caught in finishTransOut(). This distinguishes the two use cases without presenting the user with any distracting parameters, etc.
