### PR TITLE
FlxNestedSprite.isColored is not set

### DIFF
--- a/flixel/addons/display/FlxNestedSprite.hx
+++ b/flixel/addons/display/FlxNestedSprite.hx
@@ -425,6 +425,7 @@ class FlxNestedSprite extends FlxSprite
 		color.redFloat = combinedRed;
 		color.greenFloat = combinedGreen;
 		color.blueFloat = combinedBlue;
+		isColored = color.to24Bit() != 0xffffff;
 		#end
 		
 		for (child in children)


### PR DESCRIPTION
FlxNestedSprite.isColored was not set for FLX_RENDER_TILE so the 'color' was ignored under Android for example.
