### PR TITLE
Update FlxScreenGrab.hx

### DIFF
--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -161,7 +161,7 @@ class FlxScreenGrab extends FlxBasic
 		var file:FileReference = new FileReference();
 		file.save(png, Filename);
 	#elseif systools
-		var png:ByteArray = screenshot.bitmapData.encode('x');
+		var png:ByteArray = screenshot.bitmapData.encode('png');
 		var path:String = "";
 		var documentsDirectory = "";
 		var saveFile:Dynamic=null;


### PR DESCRIPTION
Changed bitmapData.encode arguments from "x" to "png" to save the screengrab in true png format with lossless quality

I used FlxScreenGrab to capture screenshots for my projects, but I noticed that the resulting files still presented artifacts even if the documentation states that they are saved as a lossless .png. When I opened them up with irfanview it tells me that it's a jpg file with incorrect extension.

I found that `bitmapData.encode` defaults to jpgencoder and can take arguments (not sure why in the current code we pass a "x"), Joshua Granick said a few words about it here: https://groups.google.com/forum/#!topic/haxelang/ATlyHJ8Dqr8

Are are the scaled up comparisons between the two methods:

deafult (jpg)
![alt text](http://i.imgur.com/aDe3iHt.png)

png
![alt text](http://i.imgur.com/lGZ0VIc.png)
