### PR TITLE
Make TiledLayer strip leading whitespace from csvData

### DIFF
--- a/flixel/addons/editors/tiled/TiledLayer.hx
+++ b/flixel/addons/editors/tiled/TiledLayer.hx
@@ -20,13 +20,13 @@ class TiledLayer
 	public var opacity:Float;
 	public var visible:Bool;
 	public var properties:TiledPropertySet;
-	
+
 	public var tiles:Array<TiledTile>;
-	
+
 	private static inline var BASE64_CHARS:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-	
+
 	private var _xmlData:Fast;
-	
+
 	public function new(Source:Fast, Parent:TiledMap)
 	{
 		properties = new TiledPropertySet();
@@ -34,46 +34,46 @@ class TiledLayer
 		name = Source.att.name;
 		x = (Source.has.x) ? Std.parseInt(Source.att.x) : 0;
 		y = (Source.has.y) ? Std.parseInt(Source.att.y) : 0;
-		width = Std.parseInt(Source.att.width); 
-		height = Std.parseInt(Source.att.height); 
+		width = Std.parseInt(Source.att.width);
+		height = Std.parseInt(Source.att.height);
 		visible = (Source.has.visible && Source.att.visible == "0") ? false : true;
 		opacity = (Source.has.opacity) ? Std.parseFloat(Source.att.opacity) : 1.0;
 		tiles = new Array<TiledTile>();
-		
+
 		// load properties
 		var node:Fast;
-		
+
 		for (node in Source.nodes.properties)
 		{
 			properties.extend(node);
 		}
-		
+
 		// load tile GIDs
 		_xmlData = Source.node.data;
-		
+
 		if (_xmlData == null)
 		{
 			throw "Error loading TiledLayer level data";
 		}
 	}
-	
+
 	public inline function getEncoding():String
 	{
 		return _xmlData.att.encoding;
 	}
-	
+
 	private function getByteArrayData():ByteArray
 	{
 		var result:ByteArray = null;
-		
+
 		if (getEncoding() == "base64")
 		{
 			var chunk:String = _xmlData.innerData;
 			var compressed:Bool = false;
-			
+
 			result = base64ToByteArray(chunk);
 			result.endian = Endian.LITTLE_ENDIAN;
-			
+
 			if (_xmlData.has.compression)
 			{
 				switch(_xmlData.att.compression)
@@ -84,7 +84,7 @@ class TiledLayer
 						throw "TiledLayer - data compression type not supported!";
 				}
 			}
-			
+
 			if (compressed)
 			{
 				#if (js && !format)
@@ -102,22 +102,22 @@ class TiledLayer
 		result.endian = Endian.LITTLE_ENDIAN;
 		return result;
 	}
-	
+
 	private static function base64ToByteArray(data:String):ByteArray
 	{
 		var output:ByteArray = new ByteArray();
-		
+
 		// initialize lookup table
 		var lookup:Array<Int> = new Array<Int>();
 		var c:Int;
-		
+
 		for (c in 0...BASE64_CHARS.length)
 		{
 			lookup[BASE64_CHARS.charCodeAt(c)] = c;
 		}
-		
+
 		var i:Int = 0;
-		
+
 		while (i < data.length - 3)
 		{
 			// Ignore whitespace
@@ -125,13 +125,13 @@ class TiledLayer
 			{
 				i++; continue;
 			}
-			
+
 			// read 4 bytes and look them up in the table
 			var a0:Int = lookup[data.charCodeAt(i)];
 			var a1:Int = lookup[data.charCodeAt(i + 1)];
 			var a2:Int = lookup[data.charCodeAt(i + 2)];
 			var a3:Int = lookup[data.charCodeAt(i + 3)];
-			
+
 			// convert to and write 3 bytes
 			if (a1 < 64)
 			{
@@ -145,20 +145,20 @@ class TiledLayer
 			{
 				output.writeByte(((a2 & 0x03) << 6) + a3);
 			}
-			
+
 			i += 4;
 		}
-		
+
 		// Rewind & return decoded data
 		output.position = 0;
-		
+
 		return output;
 	}
-	
+
 	private function resolveTile(GlobalTileID:Int):Int
 	{
 		var tile:TiledTile = new TiledTile(GlobalTileID);
-		
+
 		var tilesetID:Int = tile.tilesetID;
 		for (tileset in map.tilesets)
 		{
@@ -172,7 +172,7 @@ class TiledLayer
 		tiles.push(null);
 		return 0;
 	}
-	
+
 	/**
 	 * Function that tries to resolve the tiles gid in the csv data.
 	 * TODO: It fails because I can't find a function to parse an unsigned int from a string :(
@@ -196,21 +196,21 @@ class TiledLayer
 			}
 			buffer.add("\n");
 		}
-		
+
 		var result:String = buffer.toString();
 		buffer = null;
 		return result;
 	}
-	
+
 	public var csvData(get, null):String;
-	
-	private function get_csvData():String 
+
+	private function get_csvData():String
 	{
 		if (csvData == null)
 		{
 			if (_xmlData.att.encoding == "csv")
 			{
-				csvData = _xmlData.innerData;
+				csvData = StringTools.ltrim(_xmlData.innerData);
 			}
 			else
 			{
@@ -219,28 +219,28 @@ class TiledLayer
 		}
 		return csvData;
 	}
-	
+
 	public var tileArray(get, null):Array<Int>;
-	
+
 	private function get_tileArray():Array<Int>
 	{
 		if (tileArray == null)
 		{
 			var mapData:ByteArray = getByteArrayData();
-			
+
 			if (mapData == null)
 			{
 				throw "Must use Base64 encoding (with or without zlip compression) in order to get 1D Array.";
 			}
-			
+
 			tileArray = new Array<Int>();
-			
+
 			while (mapData.position < mapData.length)
 			{
 				tileArray.push(resolveTile(mapData.readUnsignedInt()));
 			}
 		}
-		
+
 		return tileArray;
 	}
 }


### PR DESCRIPTION
FlxTilemap blows up if the first character in a map CSV is a newline. On
at least the OS X 0.10.2 release of Tiled, layers are stored in .tmx
files with a leading newline before the actual CSV data. In an effort to
make FlxTilemap not blow up, let's just strip any leading whitespace
when we get csvData from TiledLayer.
