### PR TITLE
Exposed get level property method

### DIFF
--- a/flixel/addons/editors/ogmo/FlxOgmoLoader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmoLoader.hx
@@ -119,4 +119,16 @@ class FlxOgmoLoader
 			RectLoadCallback(FlxRect.get(Std.parseInt(r.x.get("x")), Std.parseInt(r.x.get("y")), Std.parseInt(r.x.get("w")), Std.parseInt(r.x.get("h"))));
 		}
 	}
+	    
+	/**
+	 * Allows for loading of level properties specified in Ogmo editor.
+	 * Useful for getting properties without having to manually edit the FlxOgmoLoader
+	 * Returns a String that will need to be parsed
+	 *
+	 * @param name A string that corresponds to the property to be accessed
+	 */
+	public function getProperty(name:String):String
+	{
+	        return _fastXml.att.resolve(name);
+	}
 }


### PR DESCRIPTION
Added in a method to get level properties added in through Ogmo, as there is currently no method available for extracting properties since only width and height are currently exposed.
