### PR TITLE
Remove mention to variable `isColored`

### DIFF
--- a/flixel/addons/display/FlxNestedSprite.hx
+++ b/flixel/addons/display/FlxNestedSprite.hx
@@ -425,7 +425,6 @@ class FlxNestedSprite extends FlxSprite
 		color.redFloat = combinedRed;
 		color.greenFloat = combinedGreen;
 		color.blueFloat = combinedBlue;
-		isColored = color.to24Bit() != 0xffffff;
 		#end
 		
 		for (child in children)


### PR DESCRIPTION
This var does not exist anymore and it seems like this bit of code was forgotten here.

It prevents the application from compiling in Neko and Cpp targets.