### PR TITLE
Fix FlxSpine when rendering using drawTriangles

### DIFF
--- a/flixel/addons/editors/spine/FlxSpine.hx
+++ b/flixel/addons/editors/spine/FlxSpine.hx
@@ -224,7 +224,7 @@ class FlxSpine extends FlxSprite
 					var region:RegionAttachment = cast slot.attachment;
 					verticesLength = 8;
 					region.computeWorldVertices(skeleton.x, skeleton.y, slot.bone, worldVertices);
-					uvtData = region.uvtData;
+					uvtData = region.uvs;
 					triangles = _quadTriangles;
 					
 					if (region.wrapperStrip != null)


### PR DESCRIPTION
FlxSpine depends on [spinehaxe](https://github.com/bendmorris/spinehaxe) which does not contain the property `RegionAttachment.uvtData`. This was probably a typo when updating the property names :)