### PR TITLE
Skip noLoadHash for Map Properties

### DIFF
--- a/flixel/addons/editors/tiled/TiledMap.hx
+++ b/flixel/addons/editors/tiled/TiledMap.hx
@@ -124,7 +124,7 @@ class TiledMap
 		// Load tile and object layers
 		for (el in source.elements)
 		{
-			if (noLoadHash.exists(el.att.name)) continue;
+			if (el.name.toLowerCase() != "properties" && noLoadHash.exists(el.att.name)) continue;
 			if (el.name.toLowerCase() == "layer")
 			{
 				var tileLayer = new TiledTileLayer(el, this);


### PR DESCRIPTION
this solves a bug when loading a map with Map Properties, because Tiled doesn't give it a name