### PR TITLE
Fix tiled maps with custom properties on the map not loading

### DIFF
--- a/flixel/addons/editors/tiled/TiledMap.hx
+++ b/flixel/addons/editors/tiled/TiledMap.hx
@@ -123,8 +123,9 @@ class TiledMap
 		layerMap = new Map<String, TiledLayer>();
 		// Load tile and object layers
 		for (el in source.elements)
-		{
-			if (noLoadHash.exists(el.att.name)) continue;
+		{	
+			if (el.has.name && noLoadHash.exists(el.att.name)) continue;
+			
 			if (el.name.toLowerCase() == "layer")
 			{
 				var tileLayer = new TiledTileLayer(el, this);


### PR DESCRIPTION
Loading tiled maps with custom properties threw an exception about missing attribute. Fix by checking the "name" attribute exists before trying to access it.

Fixes #178