### PR TITLE
Vertical mode in FlxWaveSprite, closes #113

### DIFF
--- a/flixel/addons/effects/FlxWaveSprite.hx
+++ b/flixel/addons/effects/FlxWaveSprite.hx
@@ -136,15 +136,15 @@ class FlxWaveSprite extends FlxSprite
 	{
 		var oldGraphic:FlxGraphic = graphic;
 		
-		var horizontalStrength = (direction == HORIZONTAL) ? strength * 2 : 0;
-		var verticalStrength = (direction == VERTICAL) ? strength * 2 : 0;
+		var horizontalStrength = (direction == HORIZONTAL) ? strength : 0;
+		var verticalStrength = (direction == VERTICAL) ? strength : 0;
 		target.drawFrame(true);
-		setPosition(target.x - strength, target.y);
+		setPosition(target.x - horizontalStrength, target.y - verticalStrength);
 		makeGraphic(
 			Std.int(target.frameWidth + horizontalStrength * 2),
 			Std.int(target.frameHeight + verticalStrength * 2),
 			FlxColor.TRANSPARENT, true);
-		_flashPoint.setTo(strength, 0);
+		_flashPoint.setTo(horizontalStrength, verticalStrength);
 		
 		pixels.copyPixels(target.framePixels, target.framePixels.rect, _flashPoint);
 		dirty = true;

--- a/flixel/addons/effects/FlxWaveSprite.hx
+++ b/flixel/addons/effects/FlxWaveSprite.hx
@@ -52,12 +52,12 @@ class FlxWaveSprite extends FlxSprite
 	 * Creates a new FlxWaveSprite, which clones a target FlxSprite and applies a wave-distortion effect to the clone.
 	 * 
 	 * @param	Target		The target FlxSprite you want to clone.
-	 * @param	Mode		Which Mode you would like to use for the effect. ALL = applies a constant distortion throughout the image, BOTTOM = makes the effect get stronger towards the bottom of the image, and TOP = the reverse of BOTTOM
+	 * @param	Mode		Which Mode you would like to use for the effect. ALL = applies a constant distortion throughout the image, END = makes the effect get stronger towards the bottom of the image, and START = the reverse of END
 	 * @param	Strength	How strong you want the effect
-	 * @param	Center		The 'center' of the effect when using BOTTOM or TOP modes. Anything above(BOTTOM)/below(TOP) this point on the image will have no distortion effect.
+	 * @param	Center		The 'center' of the effect when using END or START modes. Anything before(END)/after(START) this point on the image will have no distortion effect.
 	 * @param	Speed		How fast you want the effect to move. Higher values = faster.
 	 * @param	Wavelength	How long waves are.
-	 * @param	Direction	Which Direction you want the effect to be applied (VERTICAL or HORIZONTAL)
+	 * @param	Direction	Which Direction you want the effect to be applied (HORIZONTAL or VERTICAL)
 	 */
 	public function new(Target:FlxSprite, ?Mode:FlxWaveMode, Strength:Int = 20, Center:Int = -1, Speed:Float = 3, Wavelength:Int = 5, ?Direction:FlxWaveDirection)
 	{
@@ -67,9 +67,9 @@ class FlxWaveSprite extends FlxSprite
 		mode = (Mode == null) ? ALL : Mode;
 		speed = Speed;
 		wavelength = Wavelength;
-		direction = (Direction != null) ? Direction : VERTICAL;
+		direction = (Direction != null) ? Direction : HORIZONTAL;
 		if (Center < 0)
-			center = Std.int(((direction == VERTICAL) ? target.height : target.width) * 0.5);
+			center = Std.int(((direction == HORIZONTAL) ? target.height : target.width) * 0.5);
 		initPixels();
 		dirty = true;
 	}
@@ -89,7 +89,7 @@ class FlxWaveSprite extends FlxSprite
 		pixels.fillRect(pixels.rect, FlxColor.TRANSPARENT);
 		
 		var offset:Float = 0;
-		var length = (direction == VERTICAL) ? target.frameHeight : target.frameWidth;
+		var length = (direction == HORIZONTAL) ? target.frameHeight : target.frameWidth;
 		for (p in 0...length)
 		{
 			var offsetP:Float = center;
@@ -98,14 +98,14 @@ class FlxWaveSprite extends FlxSprite
 				case ALL:
 					offset = offsetP * calculateOffset(p);
 					
-				case BOTTOM:
+				case END:
 					if (p >= center)
 					{
 						offsetP = p - center;
 						offset = offsetP * calculateOffset(offsetP);
 					}
 					
-				case TOP:
+				case START:
 					if (p <= center)
 					{
 						offsetP = center - p;
@@ -113,7 +113,7 @@ class FlxWaveSprite extends FlxSprite
 					}
 			}
 			
-			if (direction == VERTICAL)
+			if (direction == HORIZONTAL)
 			{
 				_flashPoint.setTo(strength + offset, p);
 				_flashRect2.setTo(0, p, target.frameWidth, 1);
@@ -141,15 +141,15 @@ class FlxWaveSprite extends FlxSprite
 	{
 		var oldGraphic:FlxGraphic = graphic;
 		
-		var verticalStrength = (direction == VERTICAL) ? strength : 0;
 		var horizontalStrength = (direction == HORIZONTAL) ? strength : 0;
+		var verticalStrength = (direction == VERTICAL) ? strength : 0;
 		target.drawFrame(true);
-		setPosition(target.x - verticalStrength, target.y - horizontalStrength);
+		setPosition(target.x - horizontalStrength, target.y - verticalStrength);
 		makeGraphic(
-			Std.int(target.frameWidth + verticalStrength * 2),
-			Std.int(target.frameHeight + horizontalStrength * 2),
+			Std.int(target.frameWidth + horizontalStrength * 2),
+			Std.int(target.frameHeight + verticalStrength * 2),
 			FlxColor.TRANSPARENT, true);
-		_flashPoint.setTo(verticalStrength, horizontalStrength);
+		_flashPoint.setTo(horizontalStrength, verticalStrength);
 		
 		pixels.copyPixels(target.framePixels, target.framePixels.rect, _flashPoint);
 		dirty = true;
@@ -166,7 +166,7 @@ class FlxWaveSprite extends FlxSprite
 		return direction;
 	}
 	
-	private function set_strength(value:Int):Int 
+	private function set_strength(value:Int):Int
 	{
 		if (strength != value)
 		{
@@ -180,12 +180,12 @@ class FlxWaveSprite extends FlxSprite
 enum FlxWaveMode
 {
 	ALL;
-	TOP;
-	BOTTOM;
+	START;
+	END;
 }
 
 enum FlxWaveDirection
 {
-	VERTICAL;
 	HORIZONTAL;
+	VERTICAL;
 }

--- a/flixel/addons/effects/FlxWaveSprite.hx
+++ b/flixel/addons/effects/FlxWaveSprite.hx
@@ -53,7 +53,7 @@ class FlxWaveSprite extends FlxSprite
 	 * @param	Strength	How strong you want the effect
 	 * @param	Center		The 'center' of the effect when using BOTTOM or TOP modes. Anything above(BOTTOM)/below(TOP) this point on the image will have no distortion effect.
 	 * @param	Speed		How fast you want the effect to move. Higher values = faster.
-	 * @param	Direction	Which Direction you want the effect to be applied (HORIZONTAL or VERTICAL)
+	 * @param	Direction	Which Direction you want the effect to be applied (VERTICAL or HORIZONTAL)
 	 */
 	public function new(Target:FlxSprite, ?Mode:FlxWaveMode, Strength:Int = 20, Center:Int = -1, Speed:Float = 3, ?Direction:FlxWaveDirection) 
 	{
@@ -62,9 +62,9 @@ class FlxWaveSprite extends FlxSprite
 		strength = Strength;
 		mode = (Mode == null) ? ALL : Mode;
 		speed = Speed;
-		direction = (Direction != null) ? Direction : HORIZONTAL;
+		direction = (Direction != null) ? Direction : VERTICAL;
 		if (Center < 0)
-			center = Std.int(((direction == HORIZONTAL) ? target.height : target.width) * 0.5);
+			center = Std.int(((direction == VERTICAL) ? target.height : target.width) * 0.5);
 		initPixels();
 		dirty = true;
 	}
@@ -84,7 +84,7 @@ class FlxWaveSprite extends FlxSprite
 		pixels.fillRect(pixels.rect, FlxColor.TRANSPARENT);
 		
 		var offset:Float = 0;
-		var length = (direction == HORIZONTAL) ? target.frameHeight : target.frameWidth;
+		var length = (direction == VERTICAL) ? target.frameHeight : target.frameWidth;
 		for (oY in 0...length)
 		{
 			var p:Float = 0;
@@ -108,7 +108,7 @@ class FlxWaveSprite extends FlxSprite
 					}
 			}
 			
-			if (direction == HORIZONTAL)
+			if (direction == VERTICAL)
 			{
 				_flashPoint.setTo(strength + offset, oY);
 				_flashRect2.setTo(0, oY, target.frameWidth, 1);
@@ -136,15 +136,15 @@ class FlxWaveSprite extends FlxSprite
 	{
 		var oldGraphic:FlxGraphic = graphic;
 		
-		var horizontalStrength = (direction == HORIZONTAL) ? strength : 0;
 		var verticalStrength = (direction == VERTICAL) ? strength : 0;
+		var horizontalStrength = (direction == HORIZONTAL) ? strength : 0;
 		target.drawFrame(true);
-		setPosition(target.x - horizontalStrength, target.y - verticalStrength);
+		setPosition(target.x - verticalStrength, target.y - horizontalStrength);
 		makeGraphic(
-			Std.int(target.frameWidth + horizontalStrength * 2),
-			Std.int(target.frameHeight + verticalStrength * 2),
+			Std.int(target.frameWidth + verticalStrength * 2),
+			Std.int(target.frameHeight + horizontalStrength * 2),
 			FlxColor.TRANSPARENT, true);
-		_flashPoint.setTo(horizontalStrength, verticalStrength);
+		_flashPoint.setTo(verticalStrength, horizontalStrength);
 		
 		pixels.copyPixels(target.framePixels, target.framePixels.rect, _flashPoint);
 		dirty = true;
@@ -181,6 +181,6 @@ enum FlxWaveMode
 
 enum FlxWaveDirection
 {
-	HORIZONTAL;
 	VERTICAL;
+	HORIZONTAL;
 }

--- a/flixel/addons/effects/FlxWaveSprite.hx
+++ b/flixel/addons/effects/FlxWaveSprite.hx
@@ -1,10 +1,9 @@
 package flixel.addons.effects;
 
-import flash.geom.Point;
-import flash.geom.Rectangle;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;
+import flixel.math.FlxMath;
 import flixel.util.FlxColor;
 
 /**
@@ -39,6 +38,10 @@ class FlxWaveSprite extends FlxSprite
 	 */
 	public var direction(default, set):FlxWaveDirection;
 	/**
+	 * How long waves are
+	 */
+	public var wavelength:Int;
+	/**
 	 * How strong the wave effect should be
 	 */
 	public var strength(default, set):Int;
@@ -53,15 +56,17 @@ class FlxWaveSprite extends FlxSprite
 	 * @param	Strength	How strong you want the effect
 	 * @param	Center		The 'center' of the effect when using BOTTOM or TOP modes. Anything above(BOTTOM)/below(TOP) this point on the image will have no distortion effect.
 	 * @param	Speed		How fast you want the effect to move. Higher values = faster.
+	 * @param	Wavelength	How long waves are.
 	 * @param	Direction	Which Direction you want the effect to be applied (VERTICAL or HORIZONTAL)
 	 */
-	public function new(Target:FlxSprite, ?Mode:FlxWaveMode, Strength:Int = 20, Center:Int = -1, Speed:Float = 3, ?Direction:FlxWaveDirection) 
+	public function new(Target:FlxSprite, ?Mode:FlxWaveMode, Strength:Int = 20, Center:Int = -1, Speed:Float = 3, Wavelength:Int = 5, ?Direction:FlxWaveDirection)
 	{
 		super();
 		target = Target;
 		strength = Strength;
 		mode = (Mode == null) ? ALL : Mode;
 		speed = Speed;
+		wavelength = Wavelength;
 		direction = (Direction != null) ? Direction : VERTICAL;
 		if (Center < 0)
 			center = Std.int(((direction == VERTICAL) ? target.height : target.width) * 0.5);
@@ -85,38 +90,38 @@ class FlxWaveSprite extends FlxSprite
 		
 		var offset:Float = 0;
 		var length = (direction == VERTICAL) ? target.frameHeight : target.frameWidth;
-		for (oY in 0...length)
+		for (p in 0...length)
 		{
-			var p:Float = 0;
+			var offsetP:Float = center;
 			switch (mode)
 			{
 				case ALL:
-					offset = center * calculateOffset(oY);
+					offset = offsetP * calculateOffset(p);
 					
 				case BOTTOM:
-					if (oY >= center)
+					if (p >= center)
 					{
-						p = oY - center;
-						offset = p * calculateOffset(p);
+						offsetP = p - center;
+						offset = offsetP * calculateOffset(offsetP);
 					}
 					
 				case TOP:
-					if (oY <= center)
+					if (p <= center)
 					{
-						p = center - oY;
-						offset = p * calculateOffset(p);
+						offsetP = center - p;
+						offset = offsetP * calculateOffset(offsetP);
 					}
 			}
 			
 			if (direction == VERTICAL)
 			{
-				_flashPoint.setTo(strength + offset, oY);
-				_flashRect2.setTo(0, oY, target.frameWidth, 1);
+				_flashPoint.setTo(strength + offset, p);
+				_flashRect2.setTo(0, p, target.frameWidth, 1);
 			}
 			else
 			{
-				_flashPoint.setTo(oY, strength + offset);
-				_flashRect2.setTo(oY, 0, 1, target.frameHeight);
+				_flashPoint.setTo(p, strength + offset);
+				_flashRect2.setTo(p, 0, 1, target.frameHeight);
 			}
 			pixels.copyPixels(target.framePixels, _flashRect2, _flashPoint);
 		}
@@ -129,7 +134,7 @@ class FlxWaveSprite extends FlxSprite
 	
 	private inline function calculateOffset(p:Float):Float
 	{
-		return (strength * BASE_STRENGTH) * BASE_STRENGTH * Math.sin((0.3 * p) + _time);
+		return (strength * BASE_STRENGTH) * BASE_STRENGTH * FlxMath.fastSin((p / wavelength) + _time);
 	}
 	
 	private function initPixels():Void


### PR DESCRIPTION
add vertical direction and fix a problem with `FlxWaveMode.TOP` that `_time`
was always `= 0`

Fix issue https://github.com/HaxeFlixel/flixel-addons/issues/113