### PR TITLE
This fix the unused dragging callbacks, closes #95

### DIFF
--- a/flixel/addons/display/FlxExtendedSprite.hx
+++ b/flixel/addons/display/FlxExtendedSprite.hx
@@ -674,6 +674,11 @@ class FlxExtendedSprite extends FlxSprite
 			_dragOffsetX = Std.int(frameWidth / 2);
 			_dragOffsetY = Std.int(frameHeight / 2);
 		}
+		
+		if (mouseStartDragCallback != null)
+		{
+			mouseStartDragCallback(this, mouseX, mouseY);
+		}
 		#end
 	}
 	
@@ -736,6 +741,11 @@ class FlxExtendedSprite extends FlxSprite
 		{
 			x = (Math.floor(x / _snapX) * _snapX);
 			y = (Math.floor(y / _snapY) * _snapY);
+		}
+		
+		if (mouseStopDragCallback != null)
+		{
+			mouseStopDragCallback(this, mouseX, mouseY);
 		}
 	}
 	


### PR DESCRIPTION
Now fires `mouseStartDragCallback` and `mouseStopDragCallback`
Fix issue: https://github.com/HaxeFlixel/flixel-addons/issues/95

Why this class is `FlxExtendedSprite` and the extended version of `FlxTilemap` is called `FlxTilemapExt`?

Maybe we should rename this class to `FlxSpriteExt` to be more clean, short and similar to `FlxTilemapExt`, what you think?