### PR TITLE
Transition refactor

### DIFF
--- a/flixel/addons/display/FlxPieDial.hx
+++ b/flixel/addons/display/FlxPieDial.hx
@@ -38,13 +38,23 @@ class FlxPieDial extends FlxSprite
 		amount = FlxMath.bound(f, 0.0, 1.0);
 		var frame:Int = Std.int(f * pieFrames);
 		animation.frameIndex = frame;
+		if (amount == 1.0)
+		{
+			animation.frameIndex = 0; //special case for full frame
+		}
 		return amount;
+	}
+	
+	override public function draw():Void 
+	{
+		if (amount == 0) return;
+		super.draw();
 	}
 	
 	private function makePieDialGraphic(Radius:Int, Color:FlxColor, Frames:Int, Shape:FlxPieDialShape, Clockwise:Bool, InnerRadius:Int)
 	{
 		pieFrames = Frames;
-		var key:String = "pie_dial_" + Color.toHexString() + "_" + Radius + "_" + Frames + "_" + Shape;
+		var key:String = "pie_dial_" + Color.toHexString() + "_" + Radius + "_" + Frames + "_" + Shape + "_" + Clockwise + "_" + InnerRadius;
 		var W = Radius * 2;
 		var H = Radius * 2;
 		if (!FlxG.bitmap.checkCache(key))
@@ -62,7 +72,7 @@ class FlxPieDial extends FlxSprite
 		var H = Radius * 2;
 		
 		var rows:Int = Math.ceil(Math.sqrt(Frames));
-		var cols:Int = Math.ceil(Frames / rows);
+		var cols:Int = Math.ceil((Frames) / rows);
 		
 		var back = Clockwise ? FlxColor.BLACK : FlxColor.WHITE;
 		var fore = Clockwise ? FlxColor.WHITE : FlxColor.BLACK ;
@@ -74,9 +84,11 @@ class FlxPieDial extends FlxSprite
 		var i:Int = 0;
 		_flashPoint.setTo(0, 0);
 		var v:FlxVector = FlxVector.get(0, -1);
-		var degrees:Float = 360 / (Frames - 1);
+		var degrees:Float = 360 / (Frames);
 		if (!Clockwise)
+		{
 			degrees *= -1;
+		}
 		
 		var halfW = W / 2;
 		var halfH = H / 2;
@@ -90,7 +102,7 @@ class FlxPieDial extends FlxSprite
 		{
 			for (c in 0...cols)
 			{
-				if (i > Frames)
+				if (i >= Frames)
 				{
 					break;
 				}
@@ -100,13 +112,7 @@ class FlxPieDial extends FlxSprite
 				
 				if (i <= 0)
 				{
-					_flashRect.setTo(0, 0, W, H);
-					bmp.fillRect(_flashRect, back);
-				}
-				else if (i >= 360)
-				{
-					_flashRect.setTo(c * W, r * H, W, H);
-					bmp.fillRect(_flashRect, fore);
+					bmp.fillRect(fullBmp.rect, FlxColor.WHITE);
 				}
 				else
 				{
@@ -118,11 +124,11 @@ class FlxPieDial extends FlxSprite
 				
 				sweep += degrees;
 				v.rotateByDegrees(degrees);
-
+				
 				i++;
 			}
 			
-			if (i > Frames)
+			if (i >= Frames)
 			{
 				break;
 			}

--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -1,7 +1,7 @@
 package flixel.addons.plugin.screengrab;
 
-#if (sys && linc_dialogs)
-import dialogs.Dialogs;
+#if (sys && systools)
+import systools.Dialogs;
 #end
 
 #if !js
@@ -160,7 +160,7 @@ class FlxScreenGrab extends FlxBasic
 		var png:ByteArray = PNGEncoder.encode(screenshot.bitmapData);
 		var file:FileReference = new FileReference();
 		file.save(png, Filename);
-	#elseif linc_dialogs
+	#elseif systools
 		#if lime_legacy
 			var png:ByteArray = screenshot.bitmapData.encode('png');
 		#else
@@ -176,7 +176,7 @@ class FlxScreenGrab extends FlxBasic
 			#else
 				documentsDirectory = lime.system.System.documentsDirectory;
 			#end
-			path = Dialogs.save("", { ext:"png", desc:"png files" } );
+			path = Dialogs.saveFile("", "", "", { count:1, descriptions:["png files"], extensions:["*.png"] } );
 		}
 		catch (msg:String)
 		{
@@ -190,7 +190,7 @@ class FlxScreenGrab extends FlxBasic
 			f.close();
 		}
 	#else
-		FlxG.log.error("You need to include the 'linc_dialogs' haxelib to use the SaveToFile option.");
+		FlxG.log.error("You need to include the 'systools' haxelib to use the SaveToFile option.");
 	#end
 	}
 	

--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -1,7 +1,7 @@
 package flixel.addons.plugin.screengrab;
 
-#if (sys && systools)
-import systools.Dialogs;
+#if (sys && linc_dialogs)
+import dialogs.Dialogs;
 #end
 
 #if !js
@@ -160,7 +160,7 @@ class FlxScreenGrab extends FlxBasic
 		var png:ByteArray = PNGEncoder.encode(screenshot.bitmapData);
 		var file:FileReference = new FileReference();
 		file.save(png, Filename);
-	#elseif systools
+	#elseif linc_dialogs
 		#if lime_legacy
 			var png:ByteArray = screenshot.bitmapData.encode('png');
 		#else
@@ -176,7 +176,7 @@ class FlxScreenGrab extends FlxBasic
 			#else
 				documentsDirectory = lime.system.System.documentsDirectory;
 			#end
-			path = Dialogs.saveFile("", "", "", { count:1, descriptions:["png files"], extensions:["*.png"] } );
+			path = Dialogs.save("", { ext:"png", desc:"png files" } );
 		}
 		catch (msg:String)
 		{
@@ -190,7 +190,7 @@ class FlxScreenGrab extends FlxBasic
 			f.close();
 		}
 	#else
-		FlxG.log.error("You need to include the 'systools' haxelib to use the SaveToFile option.");
+		FlxG.log.error("You need to include the 'linc_dialogs' haxelib to use the SaveToFile option.");
 	#end
 	}
 	

--- a/flixel/addons/transition/FlxTransitionSprite.hx
+++ b/flixel/addons/transition/FlxTransitionSprite.hx
@@ -25,6 +25,9 @@ class GraphicTransTileSquare extends BitmapData {}
 class FlxTransitionSprite extends FlxSprite
 {
 	private var _delay:Float;
+	private var _count:Float;
+	private var _starting:Bool = true;
+	private var _finished:Bool = false;
 	public var status:TransitionStatus = IN;
 	private var _newStatus:TransitionStatus = NULL;
 	
@@ -62,7 +65,9 @@ class FlxTransitionSprite extends FlxSprite
 	
 	public function start(NewStatus:TransitionStatus):Void
 	{
-		new FlxTimer().start(_delay, onTimer);
+		_starting = true;
+		_finished = false;
+		_count = 0;
 		_newStatus = NewStatus;
 	}
 	
@@ -82,14 +87,15 @@ class FlxTransitionSprite extends FlxSprite
 		}
 		
 		animation.play(anim);
+		animation.finishCallback = onFinishAnim;
 		status = Status;
 	}
 	
-	override public function update(elapsed:Float):Void 
+	private function onFinishAnim(str:String):Void
 	{
-		super.update(elapsed);
-		if (animation.finished)
+		if (!_finished)
 		{
+			_finished = true;
 			switch (status) 
 			{
 				case IN:	setStatus(FULL);
@@ -99,8 +105,23 @@ class FlxTransitionSprite extends FlxSprite
 		}
 	}
 	
-	private function onTimer(f:FlxTimer = null):Void
+	override public function update(elapsed:Float):Void 
 	{
+		super.update(elapsed);
+		if (_starting)
+		{
+			_count += elapsed;
+			if (_count >= _delay)
+			{
+				onTime();
+			}
+		}
+	}
+	
+	private function onTime():Void
+	{
+		_starting = false;
+		_count = 0;
 		setStatus(_newStatus);
 		_newStatus = NULL;
 	}

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -170,8 +170,8 @@ class FlxTransitionableState extends FlxState
 	{
 		return switch(data.type)
 		{
-			case TILES: new TransitionTiles(data);
-			case FADE: new TransitionFade(data);
+			case TILES: new Transition(data);
+			case FADE: new Transition(data);
 			default: null;
 		}
 	}

--- a/flixel/addons/transition/Transition.hx
+++ b/flixel/addons/transition/Transition.hx
@@ -29,6 +29,7 @@ class Transition extends FlxSubState
 	{
 		super(FlxColor.TRANSPARENT);
 		_effect = createEffect(data);
+		_effect.scrollFactor.set(0, 0);
 		add(_effect);
 	}
 	

--- a/flixel/addons/transition/TransitionData.hx
+++ b/flixel/addons/transition/TransitionData.hx
@@ -19,7 +19,8 @@ typedef TransitionTileData =
 {
 	asset:FlxGraphicAsset,
 	width:Int,
-	height:Int
+	height:Int,
+	?frameRate:Int
 }
 
 /**

--- a/flixel/addons/transition/TransitionData.hx
+++ b/flixel/addons/transition/TransitionData.hx
@@ -1,6 +1,7 @@
 package flixel.addons.transition;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
+import flixel.math.FlxRect;
 import flixel.tweens.FlxTween.TweenOptions;
 import flixel.util.FlxColor;
 import flixel.system.FlxAssets.FlxGraphicAsset;
@@ -33,6 +34,7 @@ class TransitionData implements IFlxDestroyable
 	public var duration:Float = 1.0;
 	public var direction:FlxPoint;
 	public var tweenOptions:TweenOptions;
+	public var region:FlxRect;
 	
 	public function destroy():Void
 	{
@@ -43,7 +45,7 @@ class TransitionData implements IFlxDestroyable
 		tweenOptions = null;
 	}
 	
-	public function new(TransType:TransitionType=FADE,Color:FlxColor=FlxColor.WHITE,Duration:Float=1.0,?Direction:FlxPoint,?TileData:TransitionTileData) 
+	public function new(TransType:TransitionType=FADE,Color:FlxColor=FlxColor.WHITE,Duration:Float=1.0,?Direction:FlxPoint,?TileData:TransitionTileData,?Region:FlxRect) 
 	{
 		type = TransType;
 		tileData = TileData;
@@ -54,5 +56,10 @@ class TransitionData implements IFlxDestroyable
 		FlxMath.bound(direction.x, -1, 1);
 		FlxMath.bound(direction.y, -1, 1);
 		tweenOptions = { onComplete: null };
+		region = Region;
+		if (Region == null)
+		{
+			region = new FlxRect(0, 0, FlxG.width, FlxG.height);
+		}
 	}
 }

--- a/flixel/addons/transition/TransitionEffect.hx
+++ b/flixel/addons/transition/TransitionEffect.hx
@@ -10,9 +10,10 @@ import flixel.util.FlxTimer;
  * @author larsiusprime
  */
 @:allow(flixel.addons.transition.Transition)
-class TransitionEffect extends FlxGroup
+class TransitionEffect extends FlxSpriteGroup
 {
 	public var finishCallback:Void->Void;
+	public var finished(default, null):Bool = false;
 	
 	private var _started:Bool = false;
 	private var _endStatus:TransitionStatus;
@@ -58,6 +59,7 @@ class TransitionEffect extends FlxGroup
 	
 	private function onFinish(f:FlxTimer):Void
 	{
+		finished = true;
 		if (finishCallback != null)
 		{
 			finishCallback();

--- a/flixel/addons/transition/TransitionEffect.hx
+++ b/flixel/addons/transition/TransitionEffect.hx
@@ -1,0 +1,66 @@
+package flixel.addons.transition;
+import flixel.addons.transition.FlxTransitionSprite.TransitionStatus;
+import flixel.addons.transition.TransitionData;
+import flixel.group.FlxGroup;
+import flixel.group.FlxSpriteGroup;
+import flixel.util.FlxTimer;
+
+/**
+ * ...
+ * @author larsiusprime
+ */
+@:allow(flixel.addons.transition.Transition)
+class TransitionEffect extends FlxGroup
+{
+	public var finishCallback:Void->Void;
+	
+	private var _started:Bool = false;
+	private var _endStatus:TransitionStatus;
+	private var _finalDelayTime:Float = 0.0;
+	
+	private var _data:TransitionData;
+
+	public function new(data:TransitionData) 
+	{
+		_data = data;
+		super();
+	}
+	
+	override public function destroy():Void 
+	{
+		super.destroy();
+		finishCallback = null;
+	}
+	
+	public function start(NewStatus:TransitionStatus):Void
+	{
+		_started = true;
+		
+		if (NewStatus == IN)
+		{
+			_endStatus = FULL;
+		}
+		else
+		{
+			_endStatus = EMPTY;
+		}
+	}
+	
+	public function setStatus(NewStatus:TransitionStatus):Void
+	{
+		//override per subclass
+	}
+	
+	private function delayThenFinish():Void
+	{
+		new FlxTimer().start(_finalDelayTime, onFinish);	//force one last render call before exiting
+	}
+	
+	private function onFinish(f:FlxTimer):Void
+	{
+		if (finishCallback != null)
+		{
+			finishCallback();
+		}
+	}
+}

--- a/flixel/addons/transition/TransitionFade.hx
+++ b/flixel/addons/transition/TransitionFade.hx
@@ -1,6 +1,7 @@
 package flixel.addons.transition;
 
 import flash.display.BitmapData;
+import flixel.addons.transition.TransitionEffect;
 import flixel.addons.transition.FlxTransitionSprite.TransitionStatus;
 import flixel.FlxSprite;
 import flixel.tweens.FlxTween;
@@ -18,7 +19,7 @@ private class GraphicDiagonalGradient extends BitmapData {}
  * 
  * @author larsiusprime
  */
-class TransitionFade extends Transition
+class TransitionFade extends TransitionEffect
 {
 	private var back:FlxSprite;
 	private var tweenStr:String = "";

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -1,5 +1,7 @@
  package flixel.addons.transition;
+ 
 import flash.display.BitmapData;
+import flixel.addons.transition.TransitionEffect;
 import flixel.addons.transition.FlxTransitionSprite.TransitionStatus;
 import flixel.group.FlxGroup.FlxTypedGroup;
 
@@ -7,7 +9,7 @@ import flixel.group.FlxGroup.FlxTypedGroup;
  * 
  * @author larsiusprime
  */
-class TransitionTiles extends Transition
+class TransitionTiles extends TransitionEffect
 {
 	private var _grpSprites:FlxTypedGroup<FlxTransitionSprite>;
 	private var _isCenter:Bool = false;
@@ -26,8 +28,10 @@ class TransitionTiles extends Transition
 			data.tileData = { asset:null, width:32, height:32 };
 		}
 		
-		var tilesX:Int = Math.ceil(FlxG.width / data.tileData.width);
-		var tilesY:Int = Math.ceil(FlxG.height / data.tileData.height);
+		var region = data.region;
+		
+		var tilesX:Int = Math.ceil(region.width / data.tileData.width);
+		var tilesY:Int = Math.ceil(region.height / data.tileData.height);
 		
 		var maxTiles:Int = tilesX > tilesY ? tilesX : tilesY;
 		
@@ -42,18 +46,18 @@ class TransitionTiles extends Transition
 		var tx:Int = 0;
 		var ty:Int = 0;
 		
-		var startX:Int = 0;
-		var startY:Int = 0;
+		var startX:Int = Std.int(region.x);
+		var startY:Int = Std.int(region.y);
 		
 		if (data.direction.x < 0)
 		{
 			addX *= -1;
-			startX = FlxG.width+addX;
+			startX += Std.int(region.width + addX);
 		}
 		if (data.direction.y < 0)
 		{
 			addY *= -1;
-			startY = FlxG.height+addY;
+			startY += Std.int(region.height + addY);
 		}
 		
 		tx = startX;

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -12,14 +12,14 @@ import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
  */
 class TransitionTiles extends TransitionEffect
 {
-	private var _grpSprites:FlxTypedSpriteGroup<FlxTransitionSprite>;
+	private var _grpSprites:FlxTypedGroup<FlxTransitionSprite>;
 	private var _isCenter:Bool = false;
 	
 	public function new(data:TransitionData) 
 	{
 		super(data);
 		
-		_grpSprites = new FlxTypedSpriteGroup<FlxTransitionSprite>();
+		_grpSprites = new FlxTypedGroup<FlxTransitionSprite>();
 		var delay:Float = 0;
 		var yloops:Int = 0;
 		var xloops:Int = 0;

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -12,14 +12,14 @@ import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
  */
 class TransitionTiles extends TransitionEffect
 {
-	private var _grpSprites:FlxTypedGroup<FlxTransitionSprite>;
+	private var _grpSprites:FlxTypedSpriteGroup<FlxTransitionSprite>;
 	private var _isCenter:Bool = false;
 	
 	public function new(data:TransitionData) 
 	{
 		super(data);
 		
-		_grpSprites = new FlxTypedGroup<FlxTransitionSprite>();
+		_grpSprites = new FlxTypedSprite<FlxTransitionSprite>();
 		var delay:Float = 0;
 		var yloops:Int = 0;
 		var xloops:Int = 0;

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -19,7 +19,7 @@ class TransitionTiles extends TransitionEffect
 	{
 		super(data);
 		
-		_grpSprites = new FlxTypedSprite<FlxTransitionSprite>();
+		_grpSprites = new FlxTypedSpriteGroup<FlxTransitionSprite>();
 		var delay:Float = 0;
 		var yloops:Int = 0;
 		var xloops:Int = 0;

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -4,6 +4,7 @@ import flash.display.BitmapData;
 import flixel.addons.transition.TransitionEffect;
 import flixel.addons.transition.FlxTransitionSprite.TransitionStatus;
 import flixel.group.FlxGroup.FlxTypedGroup;
+import flixel.group.FlxSpriteGroup.FlxTypedSpriteGroup;
 
 /**
  * 
@@ -11,14 +12,14 @@ import flixel.group.FlxGroup.FlxTypedGroup;
  */
 class TransitionTiles extends TransitionEffect
 {
-	private var _grpSprites:FlxTypedGroup<FlxTransitionSprite>;
+	private var _grpSprites:FlxTypedSpriteGroup<FlxTransitionSprite>;
 	private var _isCenter:Bool = false;
 	
 	public function new(data:TransitionData) 
 	{
 		super(data);
 		
-		_grpSprites = new FlxTypedGroup<FlxTransitionSprite>();
+		_grpSprites = new FlxTypedSpriteGroup<FlxTransitionSprite>();
 		var delay:Float = 0;
 		var yloops:Int = 0;
 		var xloops:Int = 0;

--- a/flixel/addons/transition/TransitionTiles.hx
+++ b/flixel/addons/transition/TransitionTiles.hx
@@ -66,7 +66,12 @@ class TransitionTiles extends TransitionEffect
 		{
 			for (ix in 0...tilesX)
 			{
-				var ts = new FlxTransitionSprite(tx, ty, delay, data.tileData.asset);
+				var frameRate:Int = 40;
+				if (data.tileData.frameRate != null)
+				{
+					frameRate = data.tileData.frameRate;
+				}
+				var ts = new FlxTransitionSprite(tx, ty, delay, data.tileData.asset, data.tileData.width, data.tileData.height, frameRate);
 				ts.color = data.color;
 				ts.scrollFactor.set(0, 0);
 				_grpSprites.add(ts);
@@ -75,7 +80,7 @@ class TransitionTiles extends TransitionEffect
 			}
 			ty += addY;
 			tx = startX;
-			delay = 0 + (iy * yDelay);
+			delay = 0 + ((iy+1) * yDelay);
 		}
 		add(_grpSprites);
 		
@@ -119,7 +124,7 @@ class TransitionTiles extends TransitionEffect
 			var allDone:Bool = true;
 			for (sprite in _grpSprites.members)
 			{
-				if (sprite.status != _endStatus)
+				if (sprite.status != TransitionStatus.NULL && sprite.status != _endStatus)
 				{
 					allDone = false;
 					break;


### PR DESCRIPTION
Several improvements:

1. Fixed the animation timing synchronization for tiles. FlxTimer() wasn't producing reliable results, now I time things manually in update()
2. Allowed the user to specify framerate for tile transitions
3. Refactored so TileEffects can be used separately from transitions themselves (I need this functionality in Defender's Quest for the healing spell, for instance)

(I think I also accidentally pushed to a HaxeFlixel branch of "transition_refactor", feel free to delete that.)