### PR TITLE
suggestion: _length = 0; on resetText();

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -295,6 +295,7 @@ class FlxTypeText extends FlxText
 		_erasing = false;
 		paused = false;
 		_waiting = false;
+		_length = 0;
 	}
 	
 	/**


### PR DESCRIPTION
Type a new text easily with resetText();
Otherwise you're forced to erase(); before start(); every time you want to update the text.