### PR TITLE
FlxShapeArrow: subtle tweak to avoid a bug on openfl-next:

### DIFF
--- a/flixel/addons/display/shapes/FlxShapeArrow.hx
+++ b/flixel/addons/display/shapes/FlxShapeArrow.hx
@@ -70,10 +70,12 @@ class FlxShapeArrow extends FlxShape
 		
 		//generate the arrowhead
 		var vertices:Array<FlxPoint> = new Array<FlxPoint>();
+		
+		vertices.push(FlxPoint.get(0, -arrowSize));
+		vertices.push(FlxPoint.get( -arrowSize, -arrowSize));
 		vertices.push(FlxPoint.get(0, 0));
-		vertices.push(FlxPoint.get(-arrowSize, -arrowSize));
-		vertices.push(FlxPoint.get(arrowSize, -arrowSize));
-		vertices.push(FlxPoint.get(0, 0));		//close it up
+		vertices.push(FlxPoint.get( arrowSize, -arrowSize));
+		vertices.push(FlxPoint.get(0, -arrowSize));				//close it up
 		
 		//get arrowhead rotation vector
 		var fv = FlxVector.get(point.x - point2.x, point.y - point2.y);

--- a/flixel/addons/display/shapes/FlxShapeArrow.hx
+++ b/flixel/addons/display/shapes/FlxShapeArrow.hx
@@ -54,6 +54,29 @@ class FlxShapeArrow extends FlxShape
 		shape_id = FlxShapeType.ARROW;
 	}
 	
+	override private function getStrokeOffsetX():Float
+	{
+		return strokeBuffer / 6;
+	}
+	
+	override private function getStrokeOffsetY():Float
+	{
+		return strokeBuffer / 6;
+	}
+	
+	override private function get_strokeBuffer():Float
+	{
+		return lineStyle.thickness * 3.0;
+	}
+	
+	override private function getStrokeOffsetMatrix(matrix:Matrix):Matrix
+	{
+		var buffer:Float = strokeBuffer / 3;
+		matrix.identity();
+		matrix.translate(buffer, buffer);
+		return matrix;
+	}
+	
 	override public function destroy():Void
 	{
 		super.destroy();


### PR DESCRIPTION
Joint strokes don't always properly close the path on the last two points of a polygon. Yes, OpenFL should fix it, but it can be easily avoided for FlxShapeArrows by just moving the closing point to the flat "back" of the arrow where it becomes invisible, rather than leaving it at the front "point" of the arrow. This lets us get on with our lives since OpenFL will need time for a "proper" fix because closing joints messes with the guts of Cairo which could easily cause regressions.