### PR TITLE
FlxEffects minor improvements

### DIFF
--- a/flixel/addons/effects/chainable/FlxGlitchEffect.hx
+++ b/flixel/addons/effects/chainable/FlxGlitchEffect.hx
@@ -141,8 +141,11 @@ class FlxGlitchEffect implements IFlxEffect
 		}
 		
 		if (_pixels != null)
+		{
+			FlxDestroyUtil.dispose(bitmapData);
 			return _pixels.clone();
-			
+		}
+		
 		return bitmapData;
 	}
 }

--- a/flixel/addons/effects/chainable/FlxRainbowEffect.hx
+++ b/flixel/addons/effects/chainable/FlxRainbowEffect.hx
@@ -56,7 +56,7 @@ class FlxRainbowEffect implements IFlxEffect
 	 * @param	Speed		How fast the hue should change each tick.
 	 * @param	StartHue	The initial hue of the effect.
 	 */
-	public function new(Alpha:Float = 1, Brightness:Float = 1, Speed:Float = 5, StartHue:Int = 0) 
+	public function new(Alpha:Float = 1, Brightness:Float = 1, Speed:Float = 5, StartHue:Int = 0)
 	{
 		alpha = Alpha;
 		brightness = Brightness;

--- a/flixel/addons/effects/chainable/FlxShakeEffect.hx
+++ b/flixel/addons/effects/chainable/FlxShakeEffect.hx
@@ -45,7 +45,7 @@ class FlxShakeEffect implements IFlxEffect
 	 * @param	OnComplete	Optional completion callback function.
 	 * @param	Axes		On what axes to shake. Default value is XY / both.
 	 */
-	public function new(Intensity:Float = 5, Duration:Float = 0.5, ?OnComplete:Void->Void, ?Axes:FlxAxes) 
+	public function new(Intensity:Float = 5, Duration:Float = 0.5, ?OnComplete:Void->Void, ?Axes:FlxAxes)
 	{
 		intensity = Intensity;
 		_duration = Duration;
@@ -117,7 +117,7 @@ class FlxShakeEffect implements IFlxEffect
 	 * @param	OnComplete	Optional completion callback function.
 	 * @param	Axes		On what axes to shake. Default value is XY / both.
 	 */
-	public function reset(Intensity:Float = 5, Duration:Float = 0.5, ?OnComplete:Void->Void, ?Axes:FlxAxes) 
+	public function reset(Intensity:Float = 5, Duration:Float = 0.5, ?OnComplete:Void->Void, ?Axes:FlxAxes)
 	{
 		if (Axes == null)
 			Axes = XY;

--- a/flixel/addons/effects/chainable/FlxTrailEffect.hx
+++ b/flixel/addons/effects/chainable/FlxTrailEffect.hx
@@ -94,9 +94,7 @@ class FlxTrailEffect implements IFlxEffect
 		_pixels = FlxDestroyUtil.dispose(_pixels);
 	}
 	
-	public function update(elapsed:Float):Void 
-	{
-	}
+	public function update(elapsed:Float):Void {}
 	
 	public function updateRecents():Void 
 	{
@@ -152,10 +150,10 @@ class FlxTrailEffect implements IFlxEffect
 				hh = _recentPixels[i].height;
 			}
 			
-			minX = Math.min(_recentPositions[i].x -target.x, Math.min(minX, 0));
-			minY = Math.min(_recentPositions[i].y -target.y, Math.min(minY, 0));
-			maxX = Math.max(_recentPositions[i].x -target.x + ww, Math.max(maxX, 0));
-			maxY = Math.max(_recentPositions[i].y -target.y + hh, Math.max(maxY, 0));
+			minX = Math.min(_recentPositions[i].x - target.x, Math.min(minX, 0));
+			minY = Math.min(_recentPositions[i].y - target.y, Math.min(minY, 0));
+			maxX = Math.max(_recentPositions[i].x - target.x + ww, Math.max(maxX, 0));
+			maxY = Math.max(_recentPositions[i].y - target.y + hh, Math.max(maxY, 0));
 		}
 		
 		offset.set(minX, minY);
@@ -189,8 +187,8 @@ class FlxTrailEffect implements IFlxEffect
 		for (i in 0..._recentPositions.length)
 		{
 			_cTransform.alphaMultiplier = alphaDiff * i;
-			_matrix.tx = _recentPositions[i].x -target.x - offset.x;
-			_matrix.ty = _recentPositions[i].y -target.y - offset.y;
+			_matrix.tx = _recentPositions[i].x - target.x - offset.x;
+			_matrix.ty = _recentPositions[i].y - target.y - offset.y;
 			
 			if (cachePixels || _matrix.tx != 0 || _matrix.ty != 0)
 			{
@@ -214,6 +212,15 @@ class FlxTrailEffect implements IFlxEffect
 		FlxDestroyUtil.dispose(bitmapData);
 		
 		return _pixels.clone();
+	}
+	
+	public function clear():Void
+	{
+		if (_recentPositions.length > 0)
+		{
+			FlxDestroyUtil.putArray(_recentPositions);
+			disposeCachedPixels();
+		}
 	}
 	
 	private function disposeCachedPixels()

--- a/flixel/addons/effects/chainable/FlxTrailEffect.hx
+++ b/flixel/addons/effects/chainable/FlxTrailEffect.hx
@@ -57,6 +57,9 @@ class FlxTrailEffect implements IFlxEffect
 	 */
 	private var _pixels:BitmapData;
 	
+	private var _matrix:Matrix;
+	private var _cTransform:ColorTransform;
+	
 	/**
 	 * Creates a trail effect.
 	 * 
@@ -65,7 +68,7 @@ class FlxTrailEffect implements IFlxEffect
 	 * @param	FramesDelay		How many frames wait until next trail updated.
 	 * @param	CachePixels		Whether to cache current pixels bitmapData of the target for every trail position. Disable if target never update graphics.
 	 */
-	public function new(Target:FlxEffectSprite, Length:Int = 10, Alpha:Float = 0.5, FramesDelay:Int = 2, CachePixels:Bool = true) 
+	public function new(Target:FlxEffectSprite, Length:Int = 10, Alpha:Float = 0.5, FramesDelay:Int = 2, CachePixels:Bool = true)
 	{
 		target = Target;
 		length = FlxMath.maxInt(1, Length);
@@ -74,6 +77,8 @@ class FlxTrailEffect implements IFlxEffect
 		cachePixels = CachePixels;
 		
 		offset = FlxPoint.get();
+		_matrix = new Matrix();
+		_cTransform = new ColorTransform();
 	}
 	
 	public function destroy():Void 
@@ -81,6 +86,9 @@ class FlxTrailEffect implements IFlxEffect
 		disposeCachedPixels();
 		_recentPixels = null;
 		_recentPositions = FlxDestroyUtil.putArray(_recentPositions);
+		
+		_matrix = null;
+		_cTransform = null;
 		
 		offset = FlxDestroyUtil.put(offset);
 		_pixels = FlxDestroyUtil.dispose(_pixels);
@@ -136,7 +144,7 @@ class FlxTrailEffect implements IFlxEffect
 		var ww:Int = bitmapData.width;
 		var hh:Int = bitmapData.height;
 		
-		for (i in 0..._recentPositions.length) 
+		for (i in 0..._recentPositions.length)
 		{
 			if (cachePixels)
 			{
@@ -176,41 +184,41 @@ class FlxTrailEffect implements IFlxEffect
 		}
 		
 		var alphaDiff:Float = alpha / _recentPositions.length;
-		var matrix = new Matrix();
-		var cTransform = new ColorTransform();
 		
 		_pixels.lock();
-		for (i in 0..._recentPositions.length) 
+		for (i in 0..._recentPositions.length)
 		{
-			cTransform.alphaMultiplier = alphaDiff * i;
-			matrix.tx = _recentPositions[i].x -target.x - offset.x;
-			matrix.ty = _recentPositions[i].y -target.y - offset.y;
+			_cTransform.alphaMultiplier = alphaDiff * i;
+			_matrix.tx = _recentPositions[i].x -target.x - offset.x;
+			_matrix.ty = _recentPositions[i].y -target.y - offset.y;
 			
-			if (cachePixels || matrix.tx != 0 || matrix.ty != 0)
+			if (cachePixels || _matrix.tx != 0 || _matrix.ty != 0)
 			{
 				if (cachePixels && _recentPixels.length > i)
 				{
-					_pixels.draw(_recentPixels[i], matrix, cTransform);
+					_pixels.draw(_recentPixels[i], _matrix, _cTransform);
 				}
 				else
 				{
-					_pixels.draw(bitmapData, matrix, cTransform);
+					_pixels.draw(bitmapData, _matrix, _cTransform);
 				}
 			}
 		}
 		
-		matrix.tx = -offset.x;
-		matrix.ty = -offset.y;
+		_matrix.tx = -offset.x;
+		_matrix.ty = -offset.y;
 		
-		_pixels.draw(bitmapData, matrix);
+		_pixels.draw(bitmapData, _matrix);
 		_pixels.unlock();
+		
+		FlxDestroyUtil.dispose(bitmapData);
 		
 		return _pixels.clone();
 	}
 	
-	private function disposeCachedPixels() 
+	private function disposeCachedPixels()
 	{
-		while (_recentPixels.length > 0) 
+		while (_recentPixels.length > 0)
 		{
 			FlxDestroyUtil.dispose(_recentPixels.shift());
 		}

--- a/flixel/addons/effects/chainable/FlxWaveEffect.hx
+++ b/flixel/addons/effects/chainable/FlxWaveEffect.hx
@@ -71,7 +71,7 @@ class FlxWaveEffect implements IFlxEffect
 	 * @param	Wavelength	How long waves are.
 	 * @param	Direction	Which Direction you want the effect to be applied (HORIZONTAL or VERTICAL).
 	 */
-	public function new(?Mode:FlxWaveMode, Strength:Int = 10, Center:Float = -1, Speed:Float = 3, Wavelength:Int = 5, ?Direction:FlxWaveDirection) 
+	public function new(?Mode:FlxWaveMode, Strength:Int = 10, Center:Float = -1, Speed:Float = 3, Wavelength:Int = 5, ?Direction:FlxWaveDirection)
 	{
 		strength = Strength;
 		mode = (Mode == null) ? ALL : Mode;
@@ -173,7 +173,7 @@ class FlxWaveEffect implements IFlxEffect
 			
 			p += size;
 		}
-		bitmapData.dispose();
+		FlxDestroyUtil.dispose(bitmapData);
 		
 		return _pixels.clone();
 	}


### PR DESCRIPTION
FlxTrailEffect: Remove `new Matrix()` and `new ColorTransform()` from every frame
And some minor cleanup in the other effects.

I ignored `FlxOutlineEffect` for now because I'm rewriting it like described in: https://github.com/HaxeFlixel/flixel-addons/issues/228