### PR TITLE
FlxEffectSprite: added `updateTargetAnimation`

### DIFF
--- a/flixel/addons/effects/chainable/FlxEffectSprite.hx
+++ b/flixel/addons/effects/chainable/FlxEffectSprite.hx
@@ -30,6 +30,11 @@ class FlxEffectSprite extends FlxSprite
 	public var target(default, null):FlxSprite;
 	
 	/**
+	 * Whether to call target's FlxSprite#updateAnimation() every FlxEffectSprite#update(). Set this false if the target is also added to state.
+	 */
+	public var updateTarget:Bool = true;
+	
+	/**
 	 * Effects applied to frames
 	 */
 	public var effects:Array<IFlxEffect>;
@@ -131,7 +136,7 @@ class FlxEffectSprite extends FlxSprite
 	 */
 	override public function update(elapsed:Float):Void
 	{
-		if (target.animation.frames > 1)
+		if (updateTarget && target.animation.frames > 1)
 		{
 			target.updateAnimation(elapsed);
 		}

--- a/flixel/addons/effects/chainable/FlxEffectSprite.hx
+++ b/flixel/addons/effects/chainable/FlxEffectSprite.hx
@@ -32,7 +32,7 @@ class FlxEffectSprite extends FlxSprite
 	/**
 	 * Whether to call target's FlxSprite#updateAnimation() every FlxEffectSprite#update(). Set this false if the target is also added to state.
 	 */
-	public var updateTarget:Bool = true;
+	public var updateTargetAnimation:Bool = true;
 	
 	/**
 	 * Effects applied to frames
@@ -136,7 +136,7 @@ class FlxEffectSprite extends FlxSprite
 	 */
 	override public function update(elapsed:Float):Void
 	{
-		if (updateTarget && target.animation.frames > 1)
+		if (updateTargetAnimation && target.animation.frames > 1)
 		{
 			target.updateAnimation(elapsed);
 		}

--- a/flixel/addons/effects/chainable/FlxWaveEffect.hx
+++ b/flixel/addons/effects/chainable/FlxWaveEffect.hx
@@ -186,8 +186,7 @@ class FlxWaveEffect implements IFlxEffect
 
 	private function set_interlaceOffset(InterlaceOffset:Float):Float
 	{
-		interlaceOffset = FlxMath.bound(InterlaceOffset, 0, 1);
-		return interlaceOffset;
+		return interlaceOffset = FlxMath.bound(InterlaceOffset, 0, 1);
 	}
 }
 


### PR DESCRIPTION
Needed when both effectSprite eh targetSprite are added to a state to avoid calling animation twice.