### PR TITLE
FlxNapeSprite: add support for compound bodies

### DIFF
--- a/flixel/addons/nape/FlxNapeSprite.hx
+++ b/flixel/addons/nape/FlxNapeSprite.hx
@@ -93,8 +93,7 @@ class FlxNapeSprite extends FlxSprite
 			updatePhysObjects();
 		}
 	}
-
-	/**
+	
 	/**
 	 * Handy function for "killing" game objects.
 	 * Default behavior is to flag them as nonexistent AND dead.
@@ -103,13 +102,12 @@ class FlxNapeSprite extends FlxSprite
 	{
 		super.kill();
 		
-		if (body != null && body.compound == null)
+		if (body != null)
 		{
-			body.space = null;
-		}
-		else if (body.compound != null)
-		{
-			body.compound.bodies.remove(body);
+			if (body.compound == null)
+				body.space = null;
+			else
+				body.compound.bodies.remove(body);
 		}
 	}
 	
@@ -121,13 +119,12 @@ class FlxNapeSprite extends FlxSprite
 	{
 		super.revive();
 		
-		if (body != null && body.compound == null)
+		if (body != null)
 		{
-			body.space = FlxNapeSpace.space;
-		}
-		else if (body.compound != null)
-		{
-			body.compound.bodies.add(body);
+			if (body.compound == null)
+				body.space = FlxNapeSpace.space;
+			else
+				body.compound.bodies.add(body);
 		}
 	}
 	

--- a/flixel/addons/nape/FlxNapeSprite.hx
+++ b/flixel/addons/nape/FlxNapeSprite.hx
@@ -95,6 +95,7 @@ class FlxNapeSprite extends FlxSprite
 	}
 
 	/**
+	/**
 	 * Handy function for "killing" game objects.
 	 * Default behavior is to flag them as nonexistent AND dead.
 	 */
@@ -102,12 +103,16 @@ class FlxNapeSprite extends FlxSprite
 	{
 		super.kill();
 		
-		if (body != null)
+		if (body != null && body.compound == null)
 		{
 			body.space = null;
 		}
+		else if (body.compound != null)
+		{
+			body.compound.bodies.remove(body);
+		}
 	}
-
+	
 	/**
 	 * Handy function for bringing game objects "back to life". Just sets alive and exists back to true.
 	 * In practice, this function is most often called by FlxObject.reset().
@@ -116,9 +121,13 @@ class FlxNapeSprite extends FlxSprite
 	{
 		super.revive();
 		
-		if (body != null)
+		if (body != null && body.compound == null)
 		{
 			body.space = FlxNapeSpace.space;
+		}
+		else if (body.compound != null)
+		{
+			body.compound.bodies.add(body);
 		}
 	}
 	

--- a/flixel/addons/nape/FlxNapeSprite.hx
+++ b/flixel/addons/nape/FlxNapeSprite.hx
@@ -3,6 +3,7 @@ package flixel.addons.nape;
 import flixel.FlxSprite;
 import flixel.system.FlxAssets;
 import flixel.math.FlxAngle;
+import nape.constraint.Constraint;
 import nape.geom.Vec2;
 import nape.phys.Body;
 import nape.phys.BodyType;
@@ -109,6 +110,8 @@ class FlxNapeSprite extends FlxSprite
 			else
 				body.compound.bodies.remove(body);
 		}
+		
+		
 	}
 	
 	/**
@@ -223,8 +226,23 @@ class FlxNapeSprite extends FlxSprite
 	{
 		if (body != null) 
 		{
-			if (FlxNapeSpace.space != null)
-				FlxNapeSpace.space.bodies.remove(body);
+			
+			body.constraints.foreach(function(c:Constraint)
+			{
+				c.active = false;
+			});
+			
+			if (body.compound == null)
+			{
+				body.space = null;
+			}
+			else
+			{
+				body.compound.bodies.remove(body);
+			}
+			
+			
+				
 			body = null;
 		}
 	}


### PR DESCRIPTION
If the body is part of a compound, then it's space cannot be changed, instead must be added/removed from the compound bodies list
