### PR TITLE
Tiled objects should default to having a name

### DIFF
--- a/flixel/addons/editors/tiled/TiledObject.hx
+++ b/flixel/addons/editors/tiled/TiledObject.hx
@@ -73,7 +73,7 @@ class TiledObject
 	{
 		xmlData = source;
 		layer = parent;
-		name = (source.has.name) ? source.att.name : "[object]";
+		name = (source.has.name) ? source.att.name : "";
 		type = (source.has.type) ? source.att.type :
 		        (parent.properties.contains("defaultType") ? parent.properties.get("defaultType") : "");
 		x = Std.parseInt(source.att.x);


### PR DESCRIPTION
I had carried this over from the old tiled stuff, but have since realised that it does not make sense to give objects a default name. With the default name like this, in order to check if an object did not have a name, you must check for the name "[object]", which is not intuitive. Checking for an empty string is more intuitive, and better reflects the empty field in the editor.