### PR TITLE
Add offset support for Tiled.

### DIFF
--- a/flixel/addons/editors/tiled/TiledLayer.hx
+++ b/flixel/addons/editors/tiled/TiledLayer.hx
@@ -18,6 +18,8 @@ class TiledLayer
 	public var opacity:Float;
 	public var visible:Bool;
 	public var properties:TiledPropertySet;
+	public var offsetx:Float;
+	public var offsety:Float;
 
 	private function new(source:Fast, parent:TiledMap)
 	{
@@ -26,6 +28,8 @@ class TiledLayer
 		name = source.att.name;
 		visible = (source.has.visible && source.att.visible == "0") ? false : true;
 		opacity = (source.has.opacity) ? Std.parseFloat(source.att.opacity) : 1.0;
+		offsetx = (source.has.offsetx) ? Std.parseFloat(source.att.offsetx) : 0.0;
+		offsety = (source.has.offsety) ? Std.parseFloat(source.att.offsety) : 0.0;
 		
 		loadProperties(source);
 	}

--- a/flixel/addons/editors/tiled/TiledLayer.hx
+++ b/flixel/addons/editors/tiled/TiledLayer.hx
@@ -18,8 +18,8 @@ class TiledLayer
 	public var opacity:Float;
 	public var visible:Bool;
 	public var properties:TiledPropertySet;
-	public var offsetx:Float;
-	public var offsety:Float;
+	public var offsetX:Float;
+	public var offsetY:Float;
 
 	private function new(source:Fast, parent:TiledMap)
 	{
@@ -28,8 +28,8 @@ class TiledLayer
 		name = source.att.name;
 		visible = (source.has.visible && source.att.visible == "0") ? false : true;
 		opacity = (source.has.opacity) ? Std.parseFloat(source.att.opacity) : 1.0;
-		offsetx = (source.has.offsetx) ? Std.parseFloat(source.att.offsetx) : 0.0;
-		offsety = (source.has.offsety) ? Std.parseFloat(source.att.offsety) : 0.0;
+		offsetX = (source.has.offsetx) ? Std.parseFloat(source.att.offsetx) : 0.0;
+		offsetY = (source.has.offsety) ? Std.parseFloat(source.att.offsety) : 0.0;
 		
 		loadProperties(source);
 	}


### PR DESCRIPTION
I'm not sure what meaning do properties x and y in derived classes have, but this is how the positioning of layers stored in .tmx file. At least in Tiled 0.16.1