### PR TITLE
Update FlixelTextureLoader to use FlxAssets.

### DIFF
--- a/flixel/addons/editors/spine/texture/FlixelTextureLoader.hx
+++ b/flixel/addons/editors/spine/texture/FlixelTextureLoader.hx
@@ -1,7 +1,7 @@
 package flixel.addons.editors.spine.texture;
 
-import openfl.Assets;
 import openfl.display.BitmapData;
+import flixel.system.FlxAssets;
 import spinehaxe.atlas.AtlasPage;
 import spinehaxe.atlas.AtlasRegion;
 import spinehaxe.atlas.Texture;
@@ -23,7 +23,7 @@ class FlixelTextureLoader implements TextureLoader
 	
 	public function loadPage(page:AtlasPage, path:String):Void 
 	{
-		var bitmapData:BitmapData = Assets.getBitmapData(this.path + path);
+		var bitmapData:BitmapData = FlxAssets.getBitmapData(this.path + path);
 		if (bitmapData == null)
 			throw ("BitmapData not found with name: " + this.path + path);
 		page.rendererObject = bitmapData;


### PR DESCRIPTION
Currently FlixelTextureLoader uses openfl.Assets.getBitmapData which may load a cached version of a previously loaded BitmapData. Using FlxAssets to bypass the cache, so after the FlxSpine is destroyed at state change a new version of the bitmap will be loaded.