### PR TITLE
FlxTypeText: allow adding / removing more than one char per frame

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -388,12 +388,14 @@ class FlxTypeText extends FlxText
 		{
 			if (_typing && _timer >= delay)
 			{
-				_length ++;
+				_length += Std.int(_timer / delay);
+				if (_length > _finalText.length) _length = _finalText.length;
 			}
 			
 			if (_erasing && _timer >= eraseDelay)
 			{
-				_length --;
+				_length -= Std.int(_timer / eraseDelay);
+				if (_length < 0) _length = 0;
 			}
 			
 			if ((_typing && _timer >= delay) || (_erasing && _timer >= eraseDelay))
@@ -411,7 +413,7 @@ class FlxTypeText extends FlxText
 				}
 				else
 				{
-					_timer = 0;
+					_timer %= delay;
 				}
 				
 				if (sounds != null && !useDefaultSound)

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -389,13 +389,15 @@ class FlxTypeText extends FlxText
 			if (_typing && _timer >= delay)
 			{
 				_length += Std.int(_timer / delay);
-				if (_length > _finalText.length) _length = _finalText.length;
+				if (_length > _finalText.length)
+					_length = _finalText.length;
 			}
 			
 			if (_erasing && _timer >= eraseDelay)
 			{
 				_length -= Std.int(_timer / eraseDelay);
-				if (_length < 0) _length = 0;
+				if (_length < 0)
+					_length = 0;
 			}
 			
 			if ((_typing && _timer >= delay) || (_erasing && _timer >= eraseDelay))


### PR DESCRIPTION
With a low delay, the current implementation is only capable of showing or erasing one character per frame. This change allows using any delay, independent of the update rate.