### PR TITLE
Small memory optimizations (mostly involving use of haxe.ds.Vector instead of Array)

### DIFF
--- a/flixel/addons/display/FlxSpriteAniRot.hx
+++ b/flixel/addons/display/FlxSpriteAniRot.hx
@@ -1,5 +1,6 @@
 package flixel.addons.display;
 
+import haxe.ds.Vector;
 import flash.display.BitmapData;
 import flash.geom.Point;
 import flash.geom.Rectangle;
@@ -22,7 +23,7 @@ import flixel.util.FlxSpriteUtil;
  */
 class FlxSpriteAniRot extends FlxSprite
 {
-	private var framesCache:Array<FlxFramesCollection>;
+	private var framesCache:Vector<FlxFramesCollection>;
 	private var rotations:Float = 0;
 	private var angleIndex:Int = -1;
 	
@@ -47,7 +48,7 @@ class FlxSpriteAniRot extends FlxSprite
 		graphic.destroyOnNoUse = false;
 		
 		rotations = Rotations;
-		framesCache = [];
+		framesCache = new Vector(numFrames);
 		
 		var num:Int = numFrames;
 		var helperSprite:FlxSprite = new FlxSprite();
@@ -61,7 +62,7 @@ class FlxSpriteAniRot extends FlxSprite
 			// Create the rotation spritesheet for that frame
 			helperSprite.loadRotatedFrame(frameToLoad, Rotations, Antialiasing, AutoBuffer);
 			helperSprite.graphic.destroyOnNoUse = false;
-			framesCache.push(helperSprite.frames);
+			framesCache[i] = helperSprite.frames;
 		}
 		
 		helperSprite.destroy();

--- a/flixel/addons/display/FlxStarField.hx
+++ b/flixel/addons/display/FlxStarField.hx
@@ -106,11 +106,15 @@ private class FlxStarField extends FlxSprite
 {
 	public var bgColor:Int = FlxColor.BLACK;
 
+	// Why five Vectors instead of one that has an FlxStar class?  This is better
+	// for the cache, as all the data is being accessed sequentially so it'll be a
+	// little faster.
 	private var _starsX:Vector<Float>;
 	private var _starsY:Vector<Float>;
 	private var _starsD:Vector<Float>;
 	private var _starsR:Vector<Float>;
 	private var _starsSpeed:Vector<Float>;
+	// TODO: Can we speed this up more by just using one big Vector that's five times as long as StarAmount?
 
 	private var _depthColors:Array<Int>;
 	private var _minSpeed:Float;

--- a/flixel/addons/display/FlxStarField.hx
+++ b/flixel/addons/display/FlxStarField.hx
@@ -106,7 +106,6 @@ private class FlxStarField extends FlxSprite
 {
 	public var bgColor:Int = FlxColor.BLACK;
 
-	private var _starsIndex:Vector<Int>;
 	private var _starsX:Vector<Float>;
 	private var _starsY:Vector<Float>;
 	private var _starsD:Vector<Float>;
@@ -123,7 +122,6 @@ private class FlxStarField extends FlxSprite
 		Width = (Width <= 0) ? FlxG.width : Width;
 		Height = (Height <= 0) ? FlxG.height : Height;
 		makeGraphic(Width, Height, bgColor, true);
-		_starsIndex = new Vector(StarAmount);
 		_starsX = new Vector(StarAmount);
 		_starsY = new Vector(StarAmount);
 		_starsD = new Vector(StarAmount);
@@ -132,7 +130,6 @@ private class FlxStarField extends FlxSprite
 
 		for (i in 0...StarAmount)
 		{
-			_starsIndex[i] = i;
 			_starsX[i] = FlxG.random.int(0, Width);
 			_starsY[i] = FlxG.random.int(0, Height);
 			_starsD[i] = 1;
@@ -142,7 +139,6 @@ private class FlxStarField extends FlxSprite
 	
 	override public function destroy():Void
 	{
-		_starsIndex = null;
 		_starsX = null;
 		_starsY = null;
 		_starsD = null;

--- a/flixel/addons/display/FlxStarField.hx
+++ b/flixel/addons/display/FlxStarField.hx
@@ -4,6 +4,7 @@
  */
 package flixel.addons.display;
 
+import haxe.ds.Vector;
 import flixel.FlxG;
 import flixel.FlxSprite;
 import flixel.util.FlxColor;
@@ -107,7 +108,7 @@ private class FlxStarField extends FlxSprite
 {
 	public var bgColor:Int = FlxColor.BLACK;
 	
-	private var _stars:Array<FlxStar>;
+	private var _stars:Vector<FlxStar>;
 	private var _depthColors:Array<Int>;
 	private var _minSpeed:Float;
 	private var _maxSpeed:Float;
@@ -118,7 +119,7 @@ private class FlxStarField extends FlxSprite
 		Width = (Width <= 0) ? FlxG.width : Width;
 		Height = (Height <= 0) ? FlxG.height : Height;
 		makeGraphic(Width, Height, bgColor, true);
-		_stars = [];
+		_stars = new Vector(StarAmount);
 		
 		for (i in 0...StarAmount)
 		{
@@ -128,7 +129,7 @@ private class FlxStarField extends FlxSprite
 			star.y = FlxG.random.int(0, Height);
 			star.d = 1;
 			star.r = FlxG.random.float() * Math.PI * 2;
-			_stars.push(star);
+			_stars[i] = star;
 		}
 	}
 	
@@ -184,6 +185,7 @@ private class FlxStarField extends FlxSprite
 	}
 }
 
+// TODO: If we just make this a series of Vectors, will the result be cache-friendly (and thus faster)?
 private class FlxStar
 {
 	public var index:Int;

--- a/flixel/addons/display/FlxStarField.hx
+++ b/flixel/addons/display/FlxStarField.hx
@@ -33,28 +33,28 @@ class FlxStarField2D extends FlxStarField
 	
 	override public function update(elapsed:Float):Void
 	{
-		for (star in _stars)
+		for (s in 0..._starsX.length)
 		{
-			star.x += (starVelocityOffset.x * star.speed) * elapsed;
-			star.y += (starVelocityOffset.y * star.speed) * elapsed;
+			_starsX[s] += (starVelocityOffset.x * _starsSpeed[s]) * elapsed;
+			_starsY[s] += (starVelocityOffset.y * _starsSpeed[s]) * elapsed;
 			
 			// wrap the star
-			if (star.x > width)
+			if (_starsX[s] > width)
 			{
-				star.x = 0;
+				_starsX[s] = 0;
 			}
-			else if (star.x < 0)
+			else if (_starsX[s] < 0)
 			{
-				star.x = width;
+				_starsX[s] = width;
 			}
 			
-			if (star.y > height)
+			if (_starsY[s] > height)
 			{
-				star.y = 0;
+				_starsY[s] = 0;
 			}
-			else if (star.y < 0)
+			else if (_starsY[s] < 0)
 			{
-				star.y = height;
+				_starsY[s] = height;
 			}
 		}
 		
@@ -82,21 +82,19 @@ class FlxStarField3D extends FlxStarField
 	
 	override public function update(elapsed:Float):Void
 	{
-		for (star in _stars)
+		for (s in 0..._starsX.length)
 		{
-			star.d *= 1.1;
-			star.x = center.x + ((Math.cos(star.r) * star.d) * star.speed) * elapsed;
-			star.y = center.y + ((Math.sin(star.r) * star.d) * star.speed) * elapsed;
-			
-			if ((star.x < 0) || (star.x > width) || (star.y < 0) || (star.y > height))
+			_starsD[s] *= 1.1;
+			_starsX[s] = center.x + ((Math.cos(_starsR[s]) * _starsD[s]) * _starsSpeed[s]) * elapsed;
+			_starsY[s] = center.y + ((Math.sin(_starsR[s]) * _starsD[s]) * _starsSpeed[s]) * elapsed;
+
+			if ((_starsX[s] < 0) || (_starsX[s] > width) || (_starsY[s] < 0) || (_starsY[s] > height))
 			{
-				star.d = 1;
-				star.r = FlxG.random.float() * Math.PI * 2;
-				star.x = 0;
-				star.y = 0;
-				star.speed = FlxG.random.float(_minSpeed, _maxSpeed);
-				
-				_stars[star.index] = star;
+				_starsD[s] = 1;
+				_starsR[s] = FlxG.random.float() * Math.PI * 2;
+				_starsX[s] = 0;
+				_starsY[s] = 0;
+				_starsSpeed[s] = FlxG.random.float(_minSpeed, _maxSpeed);
 			}
 		}
 		
@@ -107,8 +105,14 @@ class FlxStarField3D extends FlxStarField
 private class FlxStarField extends FlxSprite
 {
 	public var bgColor:Int = FlxColor.BLACK;
-	
-	private var _stars:Vector<FlxStar>;
+
+	private var _starsIndex:Vector<Int>;
+	private var _starsX:Vector<Float>;
+	private var _starsY:Vector<Float>;
+	private var _starsD:Vector<Float>;
+	private var _starsR:Vector<Float>;
+	private var _starsSpeed:Vector<Float>;
+
 	private var _depthColors:Array<Int>;
 	private var _minSpeed:Float;
 	private var _maxSpeed:Float;
@@ -119,27 +123,31 @@ private class FlxStarField extends FlxSprite
 		Width = (Width <= 0) ? FlxG.width : Width;
 		Height = (Height <= 0) ? FlxG.height : Height;
 		makeGraphic(Width, Height, bgColor, true);
-		_stars = new Vector(StarAmount);
-		
+		_starsIndex = new Vector(StarAmount);
+		_starsX = new Vector(StarAmount);
+		_starsY = new Vector(StarAmount);
+		_starsD = new Vector(StarAmount);
+		_starsR = new Vector(StarAmount);
+		_starsSpeed = new Vector(StarAmount);
+
 		for (i in 0...StarAmount)
 		{
-			var star = new FlxStar();
-			star.index = i;
-			star.x = FlxG.random.int(0, Width);
-			star.y = FlxG.random.int(0, Height);
-			star.d = 1;
-			star.r = FlxG.random.float() * Math.PI * 2;
-			_stars[i] = star;
+			_starsIndex[i] = i;
+			_starsX[i] = FlxG.random.int(0, Width);
+			_starsY[i] = FlxG.random.int(0, Height);
+			_starsD[i] = 1;
+			_starsR[i] = FlxG.random.float() * Math.PI * 2;
 		}
 	}
 	
 	override public function destroy():Void
 	{
-		for (star in _stars)
-		{
-			star = null;
-		}
-		_stars = null;
+		_starsIndex = null;
+		_starsX = null;
+		_starsY = null;
+		_starsD = null;
+		_starsR = null;
+		_starsSpeed = null;
 		_depthColors = null;
 		super.destroy();
 	}
@@ -149,10 +157,10 @@ private class FlxStarField extends FlxSprite
 		pixels.lock();
 		pixels.fillRect(_flashRect, bgColor);
 		
-		for (star in _stars)
+		for (s in 0..._starsX.length)
 		{
-			var colorIndex:Int = Std.int(((star.speed - _minSpeed) / (_maxSpeed - _minSpeed)) * _depthColors.length);
-			pixels.setPixel32(Std.int(star.x), Std.int(star.y), _depthColors[colorIndex]);
+			var colorIndex:Int = Std.int(((_starsSpeed[s] - _minSpeed) / (_maxSpeed - _minSpeed)) * _depthColors.length);
+			pixels.setPixel32(Std.int(_starsX[s]), Std.int(_starsY[s]), _depthColors[colorIndex]);
 		}
 		
 		pixels.unlock();
@@ -178,22 +186,9 @@ private class FlxStarField extends FlxSprite
 		_minSpeed = Min;
 		_maxSpeed = Max;
 		
-		for (star in _stars)
+		for (s in 0..._starsX.length)
 		{
-			star.speed = FlxG.random.float(Min, Max);
+			_starsSpeed[s] = FlxG.random.float(Min, Max);
 		}
 	}
-}
-
-// TODO: If we just make this a series of Vectors, will the result be cache-friendly (and thus faster)?
-private class FlxStar
-{
-	public var index:Int;
-	public var x:Float;
-	public var y:Float;
-	public var d:Float;
-	public var r:Float;
-	public var speed:Float;
-	
-	public function new() {}
 }

--- a/flixel/addons/editors/tiled/TiledTileLayer.hx
+++ b/flixel/addons/editors/tiled/TiledTileLayer.hx
@@ -20,7 +20,18 @@ class TiledTileLayer extends TiledLayer
 	private var xmlData:Fast;
 
 	private static inline var BASE64_CHARS:String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/=";
-	
+	private static var BASE64_LOOKUP:Array<Int> = {
+		// initialize lookup table
+		var lookup:Array<Int> = new Array<Int>();
+
+		for (c in 0...BASE64_CHARS.length)
+		{
+			lookup[BASE64_CHARS.charCodeAt(c)] = c;
+		}
+
+		lookup;
+	};
+
 	public function new(source:Fast, parent:TiledMap)
 	{
 		super(source, parent);
@@ -85,14 +96,6 @@ class TiledTileLayer extends TiledLayer
 	{
 		var output:ByteArray = new ByteArray();
 
-		// initialize lookup table
-		var lookup:Array<Int> = new Array<Int>();
-
-		for (c in 0...BASE64_CHARS.length)
-		{
-			lookup[BASE64_CHARS.charCodeAt(c)] = c;
-		}
-
 		var i:Int = 0;
 		while (i < data.length - 3)
 		{
@@ -103,10 +106,10 @@ class TiledTileLayer extends TiledLayer
 			}
 
 			// read 4 bytes and look them up in the table
-			var a0:Int = lookup[data.charCodeAt(i)];
-			var a1:Int = lookup[data.charCodeAt(i + 1)];
-			var a2:Int = lookup[data.charCodeAt(i + 2)];
-			var a3:Int = lookup[data.charCodeAt(i + 3)];
+			var a0:Int = BASE64_LOOKUP[data.charCodeAt(i)];
+			var a1:Int = BASE64_LOOKUP[data.charCodeAt(i + 1)];
+			var a2:Int = BASE64_LOOKUP[data.charCodeAt(i + 2)];
+			var a3:Int = BASE64_LOOKUP[data.charCodeAt(i + 3)];
 
 			// convert to and write 3 bytes
 			if (a1 < 64)

--- a/flixel/addons/nape/FlxNapeTilemap.hx
+++ b/flixel/addons/nape/FlxNapeTilemap.hx
@@ -1,5 +1,6 @@
 package flixel.addons.nape;
 
+import haxe.ds.Vector;
 import flixel.addons.nape.FlxNapeSpace;
 import flixel.FlxG;
 import flixel.math.FlxPoint;
@@ -21,9 +22,9 @@ class FlxNapeTilemap extends FlxTilemap
 {
 	public var body:Body;
 	
-	private var _binaryData:Array<Int>;
 	
-	public function new() 
+	private var _binaryData:Vector<Int>;
+	public function new()
 	{
 		super();
 		body = new Body(BodyType.STATIC);
@@ -41,8 +42,7 @@ class FlxNapeTilemap extends FlxTilemap
 		?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0, DrawIndex:Int = 1, CollideIndex:Int = 1):FlxTilemap 
 	{
 		super.loadMapFromCSV(MapData, TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
-		_binaryData = new Array<Int>();
-		FlxArrayUtil.setLength(_binaryData, _data.length);
+		_binaryData = new Vector(_data.length);
 		return this;
 	}
 	
@@ -50,8 +50,7 @@ class FlxNapeTilemap extends FlxTilemap
 		TileWidth:Int = 0, TileHeight:Int = 0, ?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0, DrawIndex:Int = 1, CollideIndex:Int = 1):FlxTilemap 
 	{
 		super.loadMapFromArray(MapData, WidthInTiles, HeightInTiles, TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
-		_binaryData = new Array<Int>();
-		FlxArrayUtil.setLength(_binaryData, _data.length);
+		_binaryData = new Vector(_data.length);
 		return this;
 	}
 	
@@ -59,8 +58,7 @@ class FlxNapeTilemap extends FlxTilemap
 		?AutoTile:FlxTilemapAutoTiling, StartingIndex:Int = 0, DrawIndex:Int = 1, CollideIndex:Int = 1):FlxTilemap 
 	{
 		super.loadMapFrom2DArray(MapData, TileGraphic, TileWidth, TileHeight, AutoTile, StartingIndex, DrawIndex, CollideIndex);
-		_binaryData = new Array<Int>();
-		FlxArrayUtil.setLength(_binaryData, _data.length);
+		_binaryData = new Vector(_data.length);
 		return this;
 	}
 	


### PR DESCRIPTION
No public APIs were changed; I just went around and changed some uses of `Array<T>` to `haxe.ds.Vector<T>` when the size was fixed and known before the construction of the `Vector`.  I didn't make any radical changes either, just some low-hanging fruit.  The most notable thing I did was in `FlxStarfield`; I removed the `FlxStar` helper class entirely and replaced it with five `Vector<Float>`'s, so that it can benefit from sequential cache use.  That way, we don't have to worry about the memory allocator placing `FlxStar`s wherever it pleases.