### PR TITLE
FlxTypeText: always set callbacks

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -186,10 +186,7 @@ class FlxTypeText extends FlxText
 			skipKeys = SkipKeys;
 		}
 		
-		if (Callback != null)
-		{
-			completeCallback = Callback;
-		}
+		completeCallback = Callback;
 
 		insertBreakLines();
 		
@@ -269,10 +266,7 @@ class FlxTypeText extends FlxText
 			skipKeys = SkipKeys;
 		}
 		
-		if (Callback != null)
-		{
-			eraseCallback = Callback;
-		}
+		eraseCallback = Callback;
 		
 		#if !bitfive
 		if (useDefaultSound)


### PR DESCRIPTION
When a complete/erase callback is set, it is basically impossible to unset it since the most obvious way (not to set anything when "start" is called again, for example) does not work: the code checks for nullity of the callback argument and in that case does not (re)set it. I think it must be simply always set.
Possibly, this might be a breaking change, if code calls "start" after an initial "start" with no callback, and expects to have the same callback. However, the version in this branch is the most logical imho.
I can write tests for this if needed.