### PR TITLE
FlxTypeText: stop sounds when typing is complete

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -307,6 +307,18 @@ class FlxTypeText extends FlxText
 		_timer = 0;
 		_typing = false;
 		
+		if (useDefaultSound)
+		{
+			_sound.stop();
+		}
+		else
+		{
+			for (sound in sounds)
+			{
+				sound.stop();
+			}
+		}
+		
 		if (completeCallback != null)
 		{
 			completeCallback();


### PR DESCRIPTION
Inside "onComplete" (when typing has finished), stop all the sounds that are playing.
Had this issue in one of my prototypes. Can add unit test if you feel like it's needed.