### PR TITLE
FlxTypeText: add finishSounds

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -71,6 +71,7 @@ class FlxTypeText extends FlxText
 	public var useDefaultSound:Bool = false;
 	/**
 	 * Whether typing sound effects should always be played in their entirety, or if it's ok to restart them on new letters.
+	 * For longer typing sounds, setting this to `true` usually makes more sense.
 	 */
 	public var finishSounds = false;
 	/**

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -74,6 +74,11 @@ class FlxTypeText extends FlxText
 	 */
 	public var skipKeys:Array<FlxKey> = [];
 	/**
+	 * Controls whether playing a typing sound should stop the current one and start a
+	 * new one from the beginning or not
+	 */
+	public var restartTypingSoundOnPlay = true;
+	/**
 	 * This function is called when the message is done typing.
 	 */
 	public var completeCallback:Void->Void;
@@ -407,16 +412,19 @@ class FlxTypeText extends FlxText
 				
 				if (sounds != null && !useDefaultSound)
 				{
-					for (sound in sounds)
+					if (restartTypingSoundOnPlay)
 					{
-						sound.stop();
+						for (sound in sounds)
+						{
+							sound.stop();
+						}
 					}
 					
-					FlxG.random.getObject(sounds).play(true);
+					FlxG.random.getObject(sounds).play(restartTypingSoundOnPlay);
 				}
 				else if (useDefaultSound)
 				{
-					_sound.play(true);
+					_sound.play(restartTypingSoundOnPlay);
 				}
 			}
 		}

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -70,14 +70,13 @@ class FlxTypeText extends FlxText
 	 */
 	public var useDefaultSound:Bool = false;
 	/**
+	 * Whether typing sound effects should always be played in their entirety, or if it's ok to restart them on new letters.
+	 */
+	public var finishSounds = false;
+	/**
 	 * An array of keys as string values (e.g. "SPACE", "L") that will advance the text.
 	 */
 	public var skipKeys:Array<FlxKey> = [];
-	/**
-	 * Controls whether playing a typing sound should stop the current one and start a
-	 * new one from the beginning or not
-	 */
-	public var restartTypingSoundOnPlay = true;
 	/**
 	 * This function is called when the message is done typing.
 	 */
@@ -412,7 +411,7 @@ class FlxTypeText extends FlxText
 				
 				if (sounds != null && !useDefaultSound)
 				{
-					if (restartTypingSoundOnPlay)
+					if (!finishSounds)
 					{
 						for (sound in sounds)
 						{
@@ -420,11 +419,11 @@ class FlxTypeText extends FlxText
 						}
 					}
 					
-					FlxG.random.getObject(sounds).play(restartTypingSoundOnPlay);
+					FlxG.random.getObject(sounds).play(!finishSounds);
 				}
 				else if (useDefaultSound)
 				{
-					_sound.play(restartTypingSoundOnPlay);
+					_sound.play(!finishSounds);
 				}
 			}
 		}


### PR DESCRIPTION
Added flag "restartTypingSoundOnPlay" to control whether typing sounds should be stopped bofore playing again or not. Default is "true" which was the previous behavior.