### PR TITLE
Use radius parameter instead of recalculating it with Math.ceil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: haxe
 
 haxe:
   - 3.2.0
-  - 3.4.2
+  - development
 
 env:
   - TARGET=flash
@@ -11,6 +11,7 @@ env:
   - TARGET=html5
 
 sudo: false
+dist: trusty
 
 addons:
   apt:


### PR DESCRIPTION
Using radius parameter directly intead of `Math.ceil(width / 2), Math.ceil(height / 2)`, which are inaccurate. 

Here's a GIF showing the difference: http://i.imgur.com/b104wRC.gif