### PR TITLE
FlxTypeText: fix applyMarkup()

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -199,6 +199,13 @@ class FlxTypeText extends FlxText
 		}
 	}
 	
+	override public function applyMarkup(input:String, rules:Array<FlxTextFormatMarkerPair>):FlxText
+	{
+		super.applyMarkup(input, rules);
+		resetText(text); //Stops applyMarkup from misaligning the colored section of text.
+		return this;
+	}
+	
 	/**
 	 * Internal function that replace last space in a line for a line break.
 	 * To prevent a word start typing in a line and jump to next.


### PR DESCRIPTION
applyMarkup is inherited by FlxTypeText, but it currently causes the colour to become misaligned and prematurely terminates the string that is being typed. 

Calling resetText with the inherited text field overcomes this issue and allows markup to be normally applied. 

There is probably a neater way of doing this. 