### PR TITLE
FlxMouseControl: distinguish mouse down from mouse drag

### DIFF
--- a/flixel/addons/plugin/FlxMouseControl.hx
+++ b/flixel/addons/plugin/FlxMouseControl.hx
@@ -206,7 +206,7 @@ class FlxMouseControl extends FlxBasic
 		
 		clickTarget = _clickStack.pop();
 		
-		_clickCoords = clickTarget.point;
+		_clickCoords = new FlxPoint(FlxG.mouse.x, FlxG.mouse.y);
 		
 		_hasClickTarget = true;
 		

--- a/flixel/addons/plugin/FlxMouseControl.hx
+++ b/flixel/addons/plugin/FlxMouseControl.hx
@@ -7,6 +7,7 @@ import flixel.FlxG;
 import flixel.math.FlxMath;
 import flixel.math.FlxPoint;
 import flixel.math.FlxRect;
+import flixel.util.FlxDestroyUtil;
 
 /**
  * FlxMouseControl
@@ -73,6 +74,13 @@ class FlxMouseControl extends FlxBasic
 	private static var _oldX:Int = 0;
 	private static var _oldY:Int = 0;
 	
+	public function new()
+	{
+		super();
+		
+		_clickCoords = FlxPoint.get();
+	}
+	
 	/**
 	 * Adds the given FlxExtendedSprite to the stack of potential sprites that were clicked, the stack is then sorted and the final sprite is selected from that
 	 * 
@@ -98,6 +106,7 @@ class FlxMouseControl extends FlxBasic
 	 */
 	public static function clear():Void
 	{
+		_clickCoords = FlxDestroyUtil.put(_clickCoords);
 		_hasClickTarget = false;
 		
 		if (clickTarget != null)
@@ -206,7 +215,7 @@ class FlxMouseControl extends FlxBasic
 		
 		clickTarget = _clickStack.pop();
 		
-		_clickCoords = new FlxPoint(FlxG.mouse.x, FlxG.mouse.y);
+		_clickCoords = FlxG.mouse.getWorldPosition(null, _clickCoords);
 		
 		_hasClickTarget = true;
 		


### PR DESCRIPTION
## Summary
Correct `FlxMouseControl` bug that caused a "mouse down" to be indistinguishable from a "mouse drag start"

## Issue description
**Expected behavior:** When using `FlxExtendedSprite`, the `mouseStartDragCallback` should be fired only after the mouse has been pressed _and moved_ by at least 1 pixel.

**Actual behavior:** When using `FlxExtendedSprite`, the `mouseStartDragCallback` fires as soon as the mouse is pressed (immediately after the `mousePressedCallback` fires).

## Changes
The variable `_clickCoords` is only used in the `FlxMouseControl.hx` file on 2 lines:
- Line 209: assignment (changed) is now FlxG.mouse.x/y instead of `clickTarget.point`
- Line 142: conditional check (unchanged) tested against FlxG.mouse.x/y

These 2 values should coincide in order for the conditional check to make sense. I have chosen to update the assignment.

## Testing
Trace at line 142 before change:
```
Card.hx:49: mouse down fired
FlxMouseControl.hx:142: K: _clickCoords ,(x: 636.6 | y: 720), FlxG.mouse xy ,592, ,601
Card.hx:55: mouse drag started
FlxMouseControl.hx:142: K: _clickCoords ,(x: 636.6 | y: 720.8), FlxG.mouse xy ,592, ,601
FlxMouseControl.hx:142: K: _clickCoords ,(x: 636.6 | y: 720.8), FlxG.mouse xy ,592, ,601
[...]
FlxMouseControl.hx:142: K: _clickCoords ,(x: 636.6 | y: 720.8), FlxG.mouse xy ,592, ,601
FlxMouseControl.hx:142: K: _clickCoords ,(x: 636.6 | y: 720.8), FlxG.mouse xy ,593, ,600  // <<< Mouse moves
FlxMouseControl.hx:142: K: _clickCoords ,(x: 637.6 | y: 719.8), FlxG.mouse xy ,594, ,599
FlxMouseControl.hx:142: K: _clickCoords ,(x: 638.6 | y: 718.8), FlxG.mouse xy ,594, ,597
```

Trace at line 142 after change:
```
Card.hx:49: mouse down fired
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,623, ,620
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,623, ,620
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,623, ,620
[...]
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,623, ,620
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,620, ,618  // <<< Mouse moves
Card.hx:55: mouse drag started
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,605, ,595
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,599, ,582
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,592, ,569
FlxMouseControl.hx:142: K: _clickCoords ,(x: 623 | y: 620), FlxG.mouse xy ,587, ,558
```
