### PR TITLE
FlxExtendedSprite: Initialize _dragPixelPerfect to false

### DIFF
--- a/flixel/addons/display/FlxExtendedSprite.hx
+++ b/flixel/addons/display/FlxExtendedSprite.hx
@@ -168,7 +168,7 @@ class FlxExtendedSprite extends FlxSprite
 	private var _throwXFactor:Int;
 	private var _throwYFactor:Int;
 	
-	private var _dragPixelPerfect:Bool;
+	private var _dragPixelPerfect:Bool = false;
 	private var _dragPixelPerfectAlpha:Int;
 	private var _dragOffsetX:Int;
 	private var _dragOffsetY:Int;


### PR DESCRIPTION
## Summary
Fix a bug in `FlxExtendedSprite` where clicks are not registered without first enabling drag.

In other words:
```hx
this.enableMouseClicks(true);
// no clicks are added to the stack and no clicks will fire
```
```hx
this.enableMouseDrag()
this.enableMouseClicks(true);
// clicks get added to the stack and clicks will fire
``` 

I assume no one has noticed this because "why would you use FlxExtendedSprite just for clicks?" Well, I actually want the drag to be disabled until the user clicks, so I only enable them after a click callback. And this was a little tough to track down.

## Issue Details
Line 588 checks `_dragPixelPerfect` against `false`, but the value is actually `null` (it was not initialized on Line 171) and the check fails. `_dragPixelPerfect` would be set if you call `enableMouseDrag()` where a default value of `false` is assigned (Line 245), but if you do not do this, clicks do not fire.

## Changes
- Simple fix: Initialize _dragPixelPerfect to `false`, just like its equivalent: `_clickPixelPerfect`

## Testing
```hx
class TestSprite extends FlxExtendedSprite
{
    public function new()
    {
        super();
        this.mousePressedCallback = _onMouseDown;
        this.enableMouseClicks(true);
    }
    
    private function _onMouseDown(obj:FlxExtendedSprite, X:Int, Y:Int):Void 
    {
        trace('I was clicked!');
    }
}
```
