### PR TITLE
FlxSliceSprite: add renderedPixels

### DIFF
--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -78,6 +78,11 @@ class FlxSliceSprite extends FlxStrip
 	public var snappedHeight(get, null):Float;
 	
 	/**
+	 * Use this to get the rendered version of the graphic.
+	 */
+	public var renderedPixels(get, null):BitmapData;
+	
+	/**
 	 * Internal array of FlxGraphic objects for each element of slice grid.
 	 */
 	private var slices:Array<FlxGraphic>;
@@ -514,5 +519,13 @@ class FlxSliceSprite extends FlxStrip
 			regenGraphic();
 		
 		return _snappedHeight;
+	}
+	
+	private function get_renderedPixels():BitmapData
+	{
+		if (regen)
+			regenGraphic();
+			
+		return renderSprite.pixels;
 	}
 }

--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -80,7 +80,7 @@ class FlxSliceSprite extends FlxStrip
 	/**
 	 * Use this to get the rendered version of the graphic.
 	 */
-	public var renderedPixels(get, null):BitmapData;
+	public var renderedPixels(get, never):BitmapData;
 	
 	/**
 	 * Internal array of FlxGraphic objects for each element of slice grid.


### PR DESCRIPTION
There was no way to get the rendered version of the pixels for a `FlxSliceSprite` - for example, if you wanted to use a Slice3 sprite for a `FlxBar` or something, `pixels` always returned the original, unsliced graphic.