### PR TITLE
Fix external tilesets for tiled

### DIFF
--- a/flixel/addons/editors/tiled/TiledTileSet.hx
+++ b/flixel/addons/editors/tiled/TiledTileSet.hx
@@ -5,6 +5,7 @@ import flixel.util.typeLimit.OneOfTwo;
 import openfl.Assets;
 import openfl.utils.ByteArray;
 import haxe.xml.Fast;
+import haxe.io.Path;
 
 /**
  * Copyright (c) 2013 by Samuel Batista
@@ -58,7 +59,7 @@ class TiledTileSet
 		
 		if (source.has.source)
 		{
-			var sourcePath = rootPath + source.att.source;
+			var sourcePath = haxe.io.Path.normalize(rootPath + source.att.source);
 			if (Assets.exists(sourcePath))
 			{
 				source = new Fast(Xml.parse(Assets.getText(sourcePath)));

--- a/flixel/addons/editors/tiled/TiledTileSet.hx
+++ b/flixel/addons/editors/tiled/TiledTileSet.hx
@@ -64,6 +64,10 @@ class TiledTileSet
 				source = new Fast(Xml.parse(Assets.getText(sourcePath)));
 				source = source.node.tileset;
 			}
+			else
+			{
+				throw "Invalid TSX tileset path";
+			}
 		}
 		
 		if (!source.has.source) 
@@ -167,6 +171,10 @@ class TiledTileSet
 				numCols = Std.int(imgHeight / tileHeight);
 				numTiles = numRows * numCols;
 			}
+		}
+		else
+		{
+			throw "TMX tileset misses source image or tiles";
 		}
 	}
 	


### PR DESCRIPTION
Crash with a more meaningful error message when a path is wrong.
Support paths like `assets/data/maps/../terrains/dirt.tsx`.