### PR TITLE
FlxSliceSprite: add scale support, closes #317

### DIFF
--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -357,6 +357,7 @@ class FlxSliceSprite extends FlxStrip
 		{
 			renderSprite.x = x;
 			renderSprite.y = y;
+			renderSprite.scale.copyFrom(scale);
 			renderSprite.scrollFactor.set(scrollFactor.x, scrollFactor.y);
 			renderSprite.cameras = cameras;
 			renderSprite.draw();


### PR DESCRIPTION
Short of rewriting this extensively to use a callback point instead of a FlxPoint, this is the simplest way to make FlxSliceSprite implement scale as discussed in [#317](https://github.com/HaxeFlixel/flixel-addons/issues/317).