### PR TITLE
FlxSliceSprite: fix set_alpha()

### DIFF
--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -385,6 +385,10 @@ class FlxSliceSprite extends FlxStrip
 	
 	override function set_alpha(Alpha:Float):Float
 	{
+		if (alpha == Alpha)
+		{
+			return Alpha;
+		}
 		var newAlpha:Float = super.set_alpha(Alpha);
 		
 		if (FlxG.renderBlit && renderSprite != null)
@@ -397,7 +401,7 @@ class FlxSliceSprite extends FlxStrip
 			for (i in 0...4)
 				colors[i] = c;
 		}
-		
+		regen = true;
 		return newAlpha;
 	}
 

--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -386,9 +386,8 @@ class FlxSliceSprite extends FlxStrip
 	override function set_alpha(Alpha:Float):Float
 	{
 		if (alpha == Alpha)
-		{
 			return Alpha;
-		}
+		
 		var newAlpha:Float = super.set_alpha(Alpha);
 		
 		if (FlxG.renderBlit && renderSprite != null)


### PR DESCRIPTION
Alpha wasn't working consistently for values other than 0 and 1. I added a regen flag to the alpha setter, which solves this. I also added a check that the new alpha value is different, since forcing regen makes the alpha setter more expensive.