### PR TITLE
TiledImageLayer: document that x/y are for old Tiled versions

### DIFF
--- a/flixel/addons/editors/tiled/TiledImageLayer.hx
+++ b/flixel/addons/editors/tiled/TiledImageLayer.hx
@@ -9,11 +9,18 @@ import haxe.xml.Fast as Access;
 class TiledImageLayer extends TiledLayer
 {
 	public var imagePath:String;
+	/** Tiled version >= 0.15 uses offsetX */
+	public var x:Int;
+	/** Tiled version >= 0.15 uses offsetY */
+	public var y:Int;
 
 	public function new(source:Access, parent:TiledMap)
 	{
 		super(source, parent);
 		type = IMAGE;
 		imagePath = source.node.image.att.source;
+
+		x = (source.has.x) ? Std.parseInt(source.att.x) : 0;
+		y = (source.has.y) ? Std.parseInt(source.att.y) : 0;
 	}
 }

--- a/flixel/addons/editors/tiled/TiledImageLayer.hx
+++ b/flixel/addons/editors/tiled/TiledImageLayer.hx
@@ -9,15 +9,11 @@ import haxe.xml.Fast as Access;
 class TiledImageLayer extends TiledLayer
 {
 	public var imagePath:String;
-	public var x:Int;
-	public var y:Int;
 
 	public function new(source:Access, parent:TiledMap)
 	{
 		super(source, parent);
 		type = IMAGE;
 		imagePath = source.node.image.att.source;
-		x = (source.has.x) ? Std.parseInt(source.att.x) : 0;
-		y = (source.has.y) ? Std.parseInt(source.att.y) : 0;
 	}
 }

--- a/flixel/addons/editors/tiled/TiledImageTile.hx
+++ b/flixel/addons/editors/tiled/TiledImageTile.hx
@@ -22,7 +22,7 @@ class TiledImageTile
 	{
 		for (img in Source.nodes.image)
 		{
-			width = Std.parseFloat( img.att.width);
+			width = Std.parseFloat(img.att.width);
 			height = Std.parseFloat(img.att.height);
 			source = img.att.source;
 		}


### PR DESCRIPTION
Removes old offset properties `x` and `y` from `TiledImageLayer`. As of Tiled version 0.15 the offsets are `offsetX` and `offsetY`, which are accessible from the parent class `TiledLayer`.

TLDR: [https://github.com/elliocheerio/haxeflixel-tiled-image-layers-fix-demo](https://github.com/elliocheerio/haxeflixel-tiled-image-layers-fix-demo)