### PR TITLE
FlxTilemapExt: add setDownwardsGlue()

### DIFF
--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -410,7 +410,9 @@ class FlxTilemapExt extends FlxTilemap
 	 *
 	 * @param 	downwardsGlue  Activate/Deactivate glue on slopes on the
 	 * @param 	slopeSlowDownFactor  A slowing down factor while climbing slopes, from 0.0 to 1.0, By default 0.0, no slow down.
-	 * @param 	velocityYDownSlope The maximum velocity Y down a slope, it should be high enough to be able to use downwardsGlue. Default to 200
+	 * @param 	velocityYDownSlope The maximum velocity Y down a slope, it should be high enough to be able to use downwardsGlue. Default to 200.
+	 *
+	 * @since 2.9.0
 	 */
 	public function setDownwardsGlue(downwardsGlue:Bool, slopeSlowDownFactor:Float = 0.0, velocityYDownSlope:Float = 200):Void
 	{

--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -411,7 +411,7 @@ class FlxTilemapExt extends FlxTilemap
 	 * @param 	slopeSlowDownFactor  A slowing down factor while climbing slopes, from 0.0 to 1.0, By default 0.0, no slow down.
 	 * @param 	velocityYDownSlope The maximum velocity Y down a slope, it should be high enough to be able to use downwardsGlue. Default to 200
 	 */
-	public function setDownwardsGlue(downwardsGlue:Bool, slopeSlowDownFactor:Float, velocityYDownSlope:Float = 200):Void
+	public function setDownwardsGlue(downwardsGlue:Bool, slopeSlowDownFactor:Float = 0.0, velocityYDownSlope:Float = 200):Void
 	{
 		_downwardsGlue = downwardsGlue;
 		_slopeSlowDownFactor = 1 - slopeSlowDownFactor/10;

--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -404,8 +404,9 @@ class FlxTilemapExt extends FlxTilemap
 
 		return results;
 	}
+
 	/**
-	 * Set glue to force contact with slopes and a slow down factor while climbing 
+	 * Set glue to force contact with slopes and a slow down factor while climbing
 	 *
 	 * @param 	downwardsGlue  Activate/Deactivate glue on slopes on the
 	 * @param 	slopeSlowDownFactor  A slowing down factor while climbing slopes, from 0.0 to 1.0, By default 0.0, no slow down.
@@ -414,9 +415,10 @@ class FlxTilemapExt extends FlxTilemap
 	public function setDownwardsGlue(downwardsGlue:Bool, slopeSlowDownFactor:Float = 0.0, velocityYDownSlope:Float = 200):Void
 	{
 		_downwardsGlue = downwardsGlue;
-		_slopeSlowDownFactor = 1 - slopeSlowDownFactor/10;
+		_slopeSlowDownFactor = 1 - slopeSlowDownFactor / 10;
 		_velocityYDownSlope = velocityYDownSlope;
 	}
+
 	/**
 	 * Sets the slope arrays, which define which tiles are treated as slopes.
 	 *
@@ -541,8 +543,10 @@ class FlxTilemapExt extends FlxTilemap
 		Object.touching = FlxObject.FLOOR;
 
 		// Adjust the object's velocity
-		if(_downwardsGlue)Object.velocity.y = _velocityYDownSlope;
-		else Object.velocity.y = Math.min(Object.velocity.y, 0);
+		if (_downwardsGlue)
+			Object.velocity.y = _velocityYDownSlope;
+		else
+			Object.velocity.y = Math.min(Object.velocity.y, 0);
 
 		// Reposition the object
 		Object.y = _slopePoint.y - Object.height;
@@ -584,7 +588,7 @@ class FlxTilemapExt extends FlxTilemap
 	 */
 	function solveCollisionSlopeNorthwest(Slope:FlxObject, Object:FlxObject):Void
 	{
-		if(Object.x+ Object.width>Slope.x+Slope.width + _snapping) 
+		if (Object.x + Object.width > Slope.x + Slope.width + _snapping)
 		{
 			return;
 		}
@@ -596,7 +600,7 @@ class FlxTilemapExt extends FlxTilemap
 		// this would be one side of the object projected onto the slope's surface
 		_slopePoint.x = _objPoint.x;
 		_slopePoint.y = (Slope.y + _tileHeight) - (_slopePoint.x - Slope.x);
-		
+
 		var tileId:Int = cast(Slope, FlxTile).index;
 		if (checkThinSteep(tileId))
 		{
@@ -607,27 +611,32 @@ class FlxTilemapExt extends FlxTilemap
 			else
 			{
 				_slopePoint.y = Slope.y + _tileHeight * (2 - (2 * (_slopePoint.x - Slope.x) / _tileWidth)) + _snapping;
-				if(_downwardsGlue && Object.velocity.x>0) Object.velocity.x *= 1 - (1-_slopeSlowDownFactor)*3;
+				if (_downwardsGlue && Object.velocity.x > 0)
+					Object.velocity.x *= 1 - (1 - _slopeSlowDownFactor) * 3;
 			}
 		}
 		else if (checkThickSteep(tileId))
 		{
 			_slopePoint.y = Slope.y + _tileHeight * (1 - (2 * ((_slopePoint.x - Slope.x) / _tileWidth))) + _snapping;
-			if(_downwardsGlue && Object.velocity.x>0) Object.velocity.x *= 1 - (1-_slopeSlowDownFactor)*3;
+			if (_downwardsGlue && Object.velocity.x > 0)
+				Object.velocity.x *= 1 - (1 - _slopeSlowDownFactor) * 3;
 		}
 		else if (checkThickGentle(tileId))
 		{
 			_slopePoint.y = Slope.y + (_tileHeight - _slopePoint.x + Slope.x) / 2;
-			if(_downwardsGlue && Object.velocity.x>0) Object.velocity.x *=_slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x > 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		else if (checkThinGentle(tileId))
 		{
 			_slopePoint.y = Slope.y + _tileHeight - (_slopePoint.x - Slope.x) / 2;
-			if(_downwardsGlue && Object.velocity.x>0) Object.velocity.x *=_slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x > 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		else
 		{
-			if(_downwardsGlue && Object.velocity.x>0) Object.velocity.x *= _slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x > 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));
@@ -651,7 +660,7 @@ class FlxTilemapExt extends FlxTilemap
 	 */
 	function solveCollisionSlopeNortheast(Slope:FlxObject, Object:FlxObject):Void
 	{
-		if(Object.x<Slope.x - _snapping) 
+		if (Object.x < Slope.x - _snapping)
 		{
 			return;
 		}
@@ -675,26 +684,31 @@ class FlxTilemapExt extends FlxTilemap
 			{
 				_slopePoint.y = Slope.y + _tileHeight * 2 * ((_slopePoint.x - Slope.x) / _tileWidth) + _snapping;
 			}
-			if(_downwardsGlue && Object.velocity.x<0) Object.velocity.x *= 1 - (1-_slopeSlowDownFactor)*3;
+			if (_downwardsGlue && Object.velocity.x < 0)
+				Object.velocity.x *= 1 - (1 - _slopeSlowDownFactor) * 3;
 		}
 		else if (checkThickSteep(tileId))
 		{
 			_slopePoint.y = Slope.y - _tileHeight * (1 + (2 * ((Slope.x - _slopePoint.x) / _tileWidth))) + _snapping;
-			if(_downwardsGlue && Object.velocity.x<0) Object.velocity.x *= 1 - (1-_slopeSlowDownFactor)*3;
+			if (_downwardsGlue && Object.velocity.x < 0)
+				Object.velocity.x *= 1 - (1 - _slopeSlowDownFactor) * 3;
 		}
 		else if (checkThickGentle(tileId))
 		{
 			_slopePoint.y = Slope.y + (_tileHeight - Slope.x + _slopePoint.x - _tileWidth) / 2;
-			if(_downwardsGlue && Object.velocity.x<0) Object.velocity.x *= _slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x < 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		else if (checkThinGentle(tileId))
 		{
 			_slopePoint.y = Slope.y + _tileHeight - (Slope.x - _slopePoint.x + _tileWidth) / 2;
-			if(_downwardsGlue && Object.velocity.x<0) Object.velocity.x *= _slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x < 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		else
 		{
-			if(_downwardsGlue && Object.velocity.x<0) Object.velocity.x *=_slopeSlowDownFactor;
+			if (_downwardsGlue && Object.velocity.x < 0)
+				Object.velocity.x *= _slopeSlowDownFactor;
 		}
 		// Fix the slope point to the slope tile
 		fixSlopePoint(cast(Slope, FlxTile));


### PR DESCRIPTION
From Early Melon, who is answering my bounty.

This fix adds 10 lines and requires maxVelocity.y to be set and `setGlue(true)` on your tilemap

Example of this working can be found here:
https://github.com/chosencharacters/SlopeLand/tree/down-slope-fix

PS: Works best if the jump in your game has coyote time. When I put this into Renaine which has a pretty complicated move code, it didn't play friendly with velocities that are TOO high (as in, Renaine speed of something like 125) as they'll slide off the top, the fix for that is to ground your char as soon as they are within the tile for the first time then it works.
