### PR TITLE
`tile` Array not generated when `encoding` = 'csv'

### DIFF
--- a/flixel/addons/editors/tiled/TiledTileLayer.hx
+++ b/flixel/addons/editors/tiled/TiledTileLayer.hx
@@ -192,7 +192,7 @@ class TiledTileLayer extends TiledLayer
 					{
 						if (cell != "")
 						{
-							tileArray.push(Std.parseInt(cell));
+							tileArray.push(resolveTile(Std.parseInt(cell)));
 						}
 					}
 				}


### PR DESCRIPTION
The `tile` array is needed for special tiles (flipping/animation/etc), but it was only being generated when the map data encoding was not 'csv'