### PR TITLE
Allow finishCallback updates within callback

### DIFF
--- a/flixel/addons/transition/TransitionEffect.hx
+++ b/flixel/addons/transition/TransitionEffect.hx
@@ -62,13 +62,9 @@ class TransitionEffect extends FlxSpriteGroup
 		finished = true;
 		if (finishCallback != null)
 		{
-			var currentCallback = finishCallback;
-			finishCallback();
-
-			if (currentCallback == finishCallback)
-				finishCallback = null;
-
-			currentCallback = null;
+			var callback = finishCallback;
+			finishCallback = null;
+			callback();
 		}
 	}
 }


### PR DESCRIPTION
When changing finishCallback within an initial callback function, the new callback is set to `null` and erased on execution. This prevents that scenario by checking if the current callback is the same as the previously executed callback.