### PR TITLE
Preserve FlxTypeText's completeCallback when calling start()

### DIFF
--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -53,11 +53,10 @@ class FlxOgmo3Loader
 	 *
 	 * @param	tileGraphic		A String or Class representing the location of the image asset for the tilemap.
 	 * @param	tileLayer		The name of the layer the tilemap data is stored in Ogmo editor, usually `"tiles"` or `"stage"`.
-	 * @param	startingIndex	The index of which tile is transparent in your tileset, default is 0
 	 * @param	tilemap			(optional) A tilemap to load tilemap data into. If not specified, new `FlxTilemap` instance is created.
 	 * @return	A `FlxTilemap`, where you can collide your entities against.
 	 */
-	public function loadTilemap(tileGraphic:FlxTilemapGraphicAsset, tileLayer:String = "tiles", ?startingIndex:Int = 0, ?tilemap:FlxTilemap):FlxTilemap
+	public function loadTilemap(tileGraphic:FlxTilemapGraphicAsset, tileLayer:String = "tiles", ?tilemap:FlxTilemap):FlxTilemap
 	{
 		if (tilemap == null)
 			tilemap = new FlxTilemap();
@@ -67,8 +66,7 @@ class FlxOgmo3Loader
 		switch (layer.arrayMode)
 		{
 			case 0:
-				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight, OFF,
-					startingIndex);
+				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight);
 			case 1:
 				tilemap.loadMapFrom2DArray(layer.data2D, tileGraphic, tileset.tileWidth, tileset.tileHeight);
 		}

--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -53,10 +53,11 @@ class FlxOgmo3Loader
 	 *
 	 * @param	tileGraphic		A String or Class representing the location of the image asset for the tilemap.
 	 * @param	tileLayer		The name of the layer the tilemap data is stored in Ogmo editor, usually `"tiles"` or `"stage"`.
+	 * @param	startingIndex	The index of which tile is transparent in your tileset, default is 0
 	 * @param	tilemap			(optional) A tilemap to load tilemap data into. If not specified, new `FlxTilemap` instance is created.
 	 * @return	A `FlxTilemap`, where you can collide your entities against.
 	 */
-	public function loadTilemap(tileGraphic:FlxTilemapGraphicAsset, tileLayer:String = "tiles", ?tilemap:FlxTilemap):FlxTilemap
+	public function loadTilemap(tileGraphic:FlxTilemapGraphicAsset, tileLayer:String = "tiles", ?startingIndex:Int = 0, ?tilemap:FlxTilemap):FlxTilemap
 	{
 		if (tilemap == null)
 			tilemap = new FlxTilemap();
@@ -66,7 +67,8 @@ class FlxOgmo3Loader
 		switch (layer.arrayMode)
 		{
 			case 0:
-				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight);
+				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight, null,
+					startingIndex);
 			case 1:
 				tilemap.loadMapFrom2DArray(layer.data2D, tileGraphic, tileset.tileWidth, tileset.tileHeight);
 		}

--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -1,6 +1,7 @@
 package flixel.addons.editors.ogmo;
 
 import flixel.FlxG;
+import flixel.tile.FlxTilemapAutoTiling;
 import flixel.addons.tile.FlxTileSpecial;
 import flixel.addons.tile.FlxTilemapExt;
 import flixel.group.FlxGroup;
@@ -67,8 +68,8 @@ class FlxOgmo3Loader
 		switch (layer.arrayMode)
 		{
 			case 0:
-				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight, null,
-					startingIndex);
+				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight,
+					FlxTilemapAutoTiling.OFF, startingIndex);
 			case 1:
 				tilemap.loadMapFrom2DArray(layer.data2D, tileGraphic, tileset.tileWidth, tileset.tileHeight);
 		}

--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -1,7 +1,6 @@
 package flixel.addons.editors.ogmo;
 
 import flixel.FlxG;
-import flixel.tile.FlxTilemapAutoTiling;
 import flixel.addons.tile.FlxTileSpecial;
 import flixel.addons.tile.FlxTilemapExt;
 import flixel.group.FlxGroup;
@@ -68,8 +67,8 @@ class FlxOgmo3Loader
 		switch (layer.arrayMode)
 		{
 			case 0:
-				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight,
-					FlxTilemapAutoTiling.OFF, startingIndex);
+				tilemap.loadMapFromArray(layer.data, layer.gridCellsX, layer.gridCellsY, tileGraphic, tileset.tileWidth, tileset.tileHeight, OFF,
+					startingIndex);
 			case 1:
 				tilemap.loadMapFrom2DArray(layer.data2D, tileGraphic, tileset.tileWidth, tileset.tileHeight);
 		}

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -216,7 +216,10 @@ class FlxTypeText extends FlxText
 			skipKeys = SkipKeys;
 		}
 
-		completeCallback = Callback;
+		if (Callback != null)
+		{
+			completeCallback = Callback;
+		}
 
 		insertBreakLines();
 


### PR DESCRIPTION
I noticed that after I set the `completeCallback` and `start`ed, the callback I previously defined wouldn't run. This issue came from setting the `completeCallback` regardless if the parameter `Callback` was null or not.

[Ran a test](https://imgur.com/a/jnsVXGN) with this code and it worked:

```haxe
package;

import flixel.FlxG;
import flixel.FlxState;
import flixel.addons.text.FlxTypeText;
import flixel.text.FlxText;
import flixel.util.FlxColor;

class PlayState extends FlxState
{
	var t:FlxTypeText;	
	var lorem:String = "Lorem ipsum dolor sit amet";

	override public function create()
	{
		t = new FlxTypeText(0, 0, 500, lorem);
		t.completeCallback = textFinished;
		add(t);

		t.start();
		
		super.create();
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);
	}

	function textFinished() {
		var n = new FlxText(FlxG.random.float(0, FlxG.width), FlxG.random.float(0, FlxG.height), 0, "cool");
		var colors  = [FlxColor.BLUE, FlxColor.GREEN, FlxColor.RED]; 
		FlxG.random.shuffle(colors);
		n.color = colors[0];
		add(n);

		t.resetText(lorem);
		t.start();
	}
}
```