### PR TITLE
FlxBackdrop: enable blend, antialiasing and shader

### DIFF
--- a/flixel/addons/display/FlxBackdrop.hx
+++ b/flixel/addons/display/FlxBackdrop.hx
@@ -176,14 +176,14 @@ class FlxBackdrop extends FlxSprite
 					calcFrame(useFramePixels);
 
 				_flashRect2.setTo(0, 0, graphic.width, graphic.height);
-				camera.copyPixels(frame, framePixels, _flashRect2, _ppoint, colorTransform, blend, antialiasing);
+				camera.copyPixels(frame, framePixels, _flashRect2, _ppoint, colorTransform, blend, antialiasing, shader);
 			}
 			else
 			{
 				if (_tileFrame == null)
 					return;
 
-				var drawItem = camera.startQuadBatch(_tileFrame.parent, isColored, hasColorOffsets, blend, antialiasing);
+				var drawItem = camera.startQuadBatch(_tileFrame.parent, isColored, hasColorOffsets, blend, antialiasing, shader);
 
 				_tileFrame.prepareMatrix(_matrix);
 

--- a/flixel/addons/display/FlxBackdrop.hx
+++ b/flixel/addons/display/FlxBackdrop.hx
@@ -176,14 +176,14 @@ class FlxBackdrop extends FlxSprite
 					calcFrame(useFramePixels);
 
 				_flashRect2.setTo(0, 0, graphic.width, graphic.height);
-				camera.copyPixels(frame, framePixels, _flashRect2, _ppoint);
+				camera.copyPixels(frame, framePixels, _flashRect2, _ppoint, colorTransform, blend, antialiasing);
 			}
 			else
 			{
 				if (_tileFrame == null)
 					return;
 
-				var drawItem = camera.startQuadBatch(_tileFrame.parent, isColored, hasColorOffsets);
+				var drawItem = camera.startQuadBatch(_tileFrame.parent, isColored, hasColorOffsets, blend, antialiasing);
 
 				_tileFrame.prepareMatrix(_matrix);
 


### PR DESCRIPTION
This change allows for antialiasing, blend, and shader to work with FlxBackdrop objects. fixes #357

## Antialiasing

Before:
![2022-02-20_00-12-59_DokiTakeover](https://user-images.githubusercontent.com/15317421/154834383-dcaa66d5-e7d3-474c-bb44-10a7b437f74b.png)

After:
![image](https://user-images.githubusercontent.com/15317421/154881473-f8eaffe1-4648-445d-88aa-5b6f37d6c037.png)

## Blend

https://user-images.githubusercontent.com/15317421/154881379-b9a04b2e-a224-4c5f-a342-33cd57eaf1ea.mp4

(using SUBTRACT)
