### PR TITLE
Fix FlxOgmo3Loader.getLevelValue

### DIFF
--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -42,7 +42,7 @@ class FlxOgmo3Loader
 	 */
 	public function getLevelValue(value:String):Dynamic
 	{
-		return Reflect.field(level, value);
+		return Reflect.field(level.values, value);
 	}
 
 	/**


### PR DESCRIPTION
According to the documentation, getLevelValue should read from the custom values/properties of the level-file. These are stored under the "Values"-objectin the JSON-file, not directly under root-object.