### PR TITLE
Fixed mismatched args in FlxClothSprite

### DIFF
--- a/flixel/addons/effects/FlxClothSprite.hx
+++ b/flixel/addons/effects/FlxClothSprite.hx
@@ -200,7 +200,7 @@ class FlxClothSprite extends FlxSprite
 		if (_frameGraphic == null)
 			_frameGraphic = FlxGraphic.fromBitmapData(framePixels, false, null, false);
 
-		camera.drawTriangles(_frameGraphic, _vertices, _indices, _uvtData, colors, _point.addPoint(_drawOffset), blend, antialiasing);
+		camera.drawTriangles(_frameGraphic, _vertices, _indices, _uvtData, colors, _point.addPoint(_drawOffset), blend, false, antialiasing);
 	}
 
 	#if FLX_DEBUG


### PR DESCRIPTION
In FlxClothSprite the arguments to `camera.drawTriangles` seem to be mismatched as there needs to be one more argument between 'blend' and 'antialiasing'. This should solve that.
camera.drawTriangles function signature: https://github.com/HaxeFlixel/flixel/blob/185c94aa73f7529d7411ab5cbf9f495297f94c75/flixel/FlxCamera.hx#L759