### PR TITLE
Correct some mistakes with parameters in doc comments

### DIFF
--- a/flixel/addons/api/FlxGameJolt.hx
+++ b/flixel/addons/api/FlxGameJolt.hx
@@ -166,7 +166,7 @@ class FlxGameJolt
 
 	/**
 	 * A string map that contains what is returned from GameJolt servers.
-	 */	
+	 */
 	static var returnMap:Map<String, String> = new Map<String, String>();
 
 	/**
@@ -431,7 +431,7 @@ class FlxGameJolt
 	 * @see		https://gamejolt.com/api/doc/game/scores/fetch/
 	 * @param	Limit		The maximum number of scores to retrieve. If blank to retrieve only this user's scores.
 	 * @param 	TableID		The ID of the table you want to pull data from. Leave blank to fetch from the primary score table.
-	 * @param	CallBack	An optional callback function. Will return a Map<String:String> whose keys and values are equivalent to the key-value pairs returned by GameJolt.
+	 * @param	Callback	An optional callback function. Will return a Map<String:String> whose keys and values are equivalent to the key-value pairs returned by GameJolt.
 	 */
 	public static function fetchScore(?Limit:Int, ?TableID:Int, ?Callback:Dynamic):Void
 	{
@@ -714,7 +714,7 @@ class FlxGameJolt
 	 * However, if we're getting an image, a second URLRequest is called, and that will be done first.
 	 * Or, if we're authenticating the user, the verifyAuthentication function will be called instead.
 	 *
-	 * @param	The URLLoader complete event.
+	 * @param	e	The URLLoader complete event.
 	 */
 	static function parseData(e:Event):Void
 	{

--- a/flixel/addons/display/FlxBackdrop.hx
+++ b/flixel/addons/display/FlxBackdrop.hx
@@ -26,12 +26,12 @@ class FlxBackdrop extends FlxSprite
 	 * The axes to repeat the backdrop, defaults to XY which covers the whole camera.
 	 */
 	public var repeatAxes:FlxAxes = XY;
-	
+
 	/**
 	 * The gap between repeated tiles, defaults to (0, 0), or no gap.
 	 */
 	public var spacing(default, null):FlxPoint = new FlxPoint();
-	
+
 	/**
 	 * If true, tiles are pre-rendered to a intermediary bitmap whenever `loadGraphic` is called
 	 * or the following properties are changed: camera size camera zoom, `scale.x`, `scale.y`,
@@ -41,29 +41,28 @@ class FlxBackdrop extends FlxSprite
 	 * Note: blitting will disable animations and only show the first frame.
 	 */
 	public var drawBlit:Bool = FlxG.renderBlit;
-	
+
 	/**
 	 * Decides the the size of the blit graphic. Leave as `AUTO` unless you know what you're doing.
 	 * 
 	 * @see flixel.addons.display.FlxBackDrop.BackdropBlitMode
 	 */
 	public var blitMode:BackdropBlitMode = AUTO;
-	
+
 	var _blitOffset:FlxPoint = FlxPoint.get();
 	var _blitGraphic:FlxGraphic = null;
-	var _prevDrawParams:BackdropDrawParams =
-	{
-		graphicKey:null,
-		tilesX:-1,
-		tilesY:-1,
-		scaleX:0.0,
-		scaleY:0.0,
-		spacingX:0.0,
-		spacingY:0.0,
-		repeatAxes:XY,
-		angle:0.0
+	var _prevDrawParams:BackdropDrawParams = {
+		graphicKey: null,
+		tilesX: -1,
+		tilesY: -1,
+		scaleX: 0.0,
+		scaleY: 0.0,
+		spacingX: 0.0,
+		spacingY: 0.0,
+		repeatAxes: XY,
+		angle: 0.0
 	};
-	
+
 	/**
 	 * Creates an instance of the FlxBackdrop class, used to create infinitely scrolling backgrounds.
 	 *
@@ -75,7 +74,7 @@ class FlxBackdrop extends FlxSprite
 	public function new(?graphic:FlxGraphicAsset, repeatAxes = XY, spacingX = 0, spacingY = 0)
 	{
 		super(0, 0, graphic);
-		
+
 		this.repeatAxes = repeatAxes;
 		this.spacing.set(spacingX, spacingY);
 	}
@@ -85,10 +84,10 @@ class FlxBackdrop extends FlxSprite
 		spacing = FlxDestroyUtil.destroy(spacing);
 		_blitOffset = FlxDestroyUtil.destroy(_blitOffset);
 		_blitGraphic = FlxDestroyUtil.destroy(_blitGraphic);
-		
+
 		super.destroy();
 	}
-	
+
 	override function draw()
 	{
 		if (repeatAxes == NONE)
@@ -96,7 +95,7 @@ class FlxBackdrop extends FlxSprite
 			super.draw();
 			return;
 		}
-		
+
 		checkEmptyFrame();
 
 		if (alpha == 0 || _frame.type == FlxFrameType.EMPTY)
@@ -112,7 +111,7 @@ class FlxBackdrop extends FlxSprite
 		{
 			drawToLargestCamera();
 		}
-		
+
 		for (camera in cameras)
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
@@ -138,22 +137,24 @@ class FlxBackdrop extends FlxSprite
 	{
 		if (repeatAxes == XY)
 			return true;
-		
+
 		if (repeatAxes == NONE)
 			return super.isOnScreen(camera);
-		
+
 		if (camera == null)
 			camera = FlxG.camera;
-		
+
 		var bounds = getScreenBounds(_rect, camera);
 		var view = camera.getViewRect();
-		if (repeatAxes.x) bounds.x = view.x;
-		if (repeatAxes.y) bounds.y = view.y;
+		if (repeatAxes.x)
+			bounds.x = view.x;
+		if (repeatAxes.y)
+			bounds.y = view.y;
 		view.put();
-		
+
 		return camera.containsRect(bounds);
 	}
-	
+
 	function drawToLargestCamera()
 	{
 		var largest:FlxCamera = null;
@@ -163,7 +164,7 @@ class FlxBackdrop extends FlxSprite
 		{
 			if (!camera.visible || !camera.exists || !isOnScreen(camera))
 				continue;
-			
+
 			camera.getViewRect(view);
 			if (view.width * view.height > largestArea)
 			{
@@ -172,20 +173,19 @@ class FlxBackdrop extends FlxSprite
 			}
 		}
 		view.put();
-		
+
 		if (largest != null)
 			regenGraphic(largest);
 	}
-	
+
 	override function isSimpleRenderBlit(?camera:FlxCamera):Bool
 	{
 		if (repeatAxes == NONE)
 			return super.isSimpleRenderBlit(camera);
-		
-		return (super.isSimpleRenderBlit(camera) || drawBlit)
-			&& (camera != null ? isPixelPerfectRender(camera) : pixelPerfectRender);
+
+		return (super.isSimpleRenderBlit(camera) || drawBlit) && (camera != null ? isPixelPerfectRender(camera) : pixelPerfectRender);
 	}
-	
+
 	override function drawSimple(camera:FlxCamera):Void
 	{
 		if (repeatAxes == NONE)
@@ -193,16 +193,16 @@ class FlxBackdrop extends FlxSprite
 			super.drawSimple(camera);
 			return;
 		}
-		
+
 		var drawDirect = !drawBlit;
 		final graphic = drawBlit ? _blitGraphic : this.graphic;
 		final frame = drawBlit ? _blitGraphic.imageFrame.frame : _frame;
-		
+
 		// The distance between repeated sprites, in screen space
 		var tileSize = FlxPoint.get(frame.frame.width, frame.frame.height);
 		if (drawDirect)
 			tileSize.addPoint(spacing);
-		
+
 		getScreenPosition(_point, camera).subtractPoint(offset);
 		var tilesX = 1;
 		var tilesY = 1;
@@ -211,49 +211,49 @@ class FlxBackdrop extends FlxSprite
 			var view = camera.getViewRect();
 			if (repeatAxes.x)
 			{
-				final left  = modMin(_point.x + frameWidth, tileSize.x, view.left) - frameWidth;
+				final left = modMin(_point.x + frameWidth, tileSize.x, view.left) - frameWidth;
 				final right = modMax(_point.x, tileSize.x, view.right) + tileSize.x;
 				tilesX = Math.round((right - left) / tileSize.x);
 				final origTileSizeX = frameWidth + spacing.x;
 				_point.x = modMin(_point.x + frameWidth, origTileSizeX, view.left) - frameWidth;
 			}
-			
+
 			if (repeatAxes.y)
 			{
-				final top    = modMin(_point.y + frameHeight, tileSize.y, view.top) - frameHeight;
+				final top = modMin(_point.y + frameHeight, tileSize.y, view.top) - frameHeight;
 				final bottom = modMax(_point.y, tileSize.y, view.bottom) + tileSize.y;
 				tilesY = Math.round((bottom - top) / tileSize.y);
 				final origTileSizeY = frameHeight + spacing.y;
 				_point.y = modMin(_point.y + frameHeight, origTileSizeY, view.top) - frameHeight;
 			}
 		}
-		
+
 		if (drawBlit)
 			_point.addPoint(_blitOffset);
-		
+
 		if (FlxG.renderBlit)
 			calcFrame(true);
-		
+
 		camera.buffer.lock();
-		
+
 		for (tileX in 0...tilesX)
 		{
 			for (tileY in 0...tilesY)
 			{
 				// _point.copyToFlash(_flashPoint);
 				_flashPoint.setTo(_point.x + tileSize.x * tileX, _point.y + tileSize.y * tileY);
-				
+
 				if (isPixelPerfectRender(camera))
 				{
 					_flashPoint.x = Math.floor(_flashPoint.x);
 					_flashPoint.y = Math.floor(_flashPoint.y);
 				}
-				
-				final pixels = drawBlit ? _blitGraphic.bitmap: framePixels;
+
+				final pixels = drawBlit ? _blitGraphic.bitmap : framePixels;
 				camera.copyPixels(frame, pixels, pixels.rect, _flashPoint, colorTransform, blend, antialiasing);
 			}
 		}
-		
+
 		camera.buffer.unlock();
 	}
 
@@ -264,25 +264,21 @@ class FlxBackdrop extends FlxSprite
 			super.drawComplex(camera);
 			return;
 		}
-		
+
 		var drawDirect = !drawBlit;
 		final graphic = drawBlit ? _blitGraphic : this.graphic;
 		final frame = drawBlit ? _blitGraphic.imageFrame.frame : _frame;
-		
+
 		frame.prepareMatrix(_matrix, FlxFrameAngle.ANGLE_0, checkFlipX(), checkFlipY());
 		_matrix.translate(-origin.x, -origin.y);
-		
+
 		// The distance between repeated sprites, in screen space
 		var tileSize = FlxPoint.get(frame.frame.width, frame.frame.height);
-		
+
 		if (drawDirect)
 		{
-			tileSize.set
-			(
-				(frame.frame.width  + spacing.x) * scale.x,
-				(frame.frame.height + spacing.y) * scale.y
-			);
-			
+			tileSize.set((frame.frame.width + spacing.x) * scale.x, (frame.frame.height + spacing.y) * scale.y);
+
 			_matrix.scale(scale.x, scale.y);
 
 			if (bakedRotationAngle <= 0)
@@ -293,7 +289,7 @@ class FlxBackdrop extends FlxSprite
 					_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 			}
 		}
-		
+
 		var drawItem = null;
 		if (FlxG.renderTile)
 		{
@@ -305,7 +301,7 @@ class FlxBackdrop extends FlxSprite
 		{
 			camera.buffer.lock();
 		}
-		
+
 		getScreenPosition(_point, camera).subtractPoint(offset);
 		var tilesX = 1;
 		var tilesY = 1;
@@ -316,16 +312,16 @@ class FlxBackdrop extends FlxSprite
 			if (repeatAxes.x)
 			{
 				final origTileSizeX = (frameWidth + spacing.x) * scale.x;
-				final left  = modMin(bounds.right, origTileSizeX, view.left) - bounds.width;
+				final left = modMin(bounds.right, origTileSizeX, view.left) - bounds.width;
 				final right = modMax(bounds.left, origTileSizeX, view.right) + origTileSizeX;
 				tilesX = Math.round((right - left) / tileSize.x);
 				_point.x = left + _point.x - bounds.x;
 			}
-			
+
 			if (repeatAxes.y)
 			{
 				final origTileSizeY = (frameHeight + spacing.y) * scale.y;
-				final top    = modMin(bounds.bottom, origTileSizeY, view.top) - bounds.height;
+				final top = modMin(bounds.bottom, origTileSizeY, view.top) - bounds.height;
 				final bottom = modMax(bounds.top, origTileSizeY, view.bottom) + origTileSizeY;
 				tilesY = Math.round((bottom - top) / tileSize.y);
 				_point.y = top + _point.y - bounds.y;
@@ -336,25 +332,25 @@ class FlxBackdrop extends FlxSprite
 		_point.addPoint(origin);
 		if (drawBlit)
 			_point.addPoint(_blitOffset);
-		
+
 		final mat = new FlxMatrix();
 		for (tileX in 0...tilesX)
 		{
 			for (tileY in 0...tilesY)
 			{
 				mat.copyFrom(_matrix);
-				
+
 				mat.translate(_point.x + (tileSize.x * tileX), _point.y + (tileSize.y * tileY));
-				
+
 				if (isPixelPerfectRender(camera))
 				{
 					mat.tx = Math.floor(mat.tx);
 					mat.ty = Math.floor(mat.ty);
 				}
-				
+
 				if (FlxG.renderBlit)
 				{
-					final pixels = drawBlit ? _blitGraphic.bitmap: framePixels;
+					final pixels = drawBlit ? _blitGraphic.bitmap : framePixels;
 					camera.drawPixels(frame, pixels, mat, colorTransform, blend, antialiasing, shader);
 				}
 				else
@@ -363,11 +359,11 @@ class FlxBackdrop extends FlxSprite
 				}
 			}
 		}
-		
+
 		if (FlxG.renderBlit)
 			camera.buffer.unlock();
 	}
-	
+
 	function getFrameScreenBounds(camera:FlxCamera):FlxRect
 	{
 		if (drawBlit)
@@ -375,9 +371,9 @@ class FlxBackdrop extends FlxSprite
 			final frame = _blitGraphic.imageFrame.frame.frame;
 			return FlxRect.get(x, y, frame.width, frame.height);
 		}
-		
+
 		final newRect = FlxRect.get(x, y);
-		
+
 		if (pixelPerfectPosition)
 			newRect.floor();
 		final scaledOrigin = FlxPoint.weak(origin.x * scale.x, origin.y * scale.y);
@@ -388,58 +384,64 @@ class FlxBackdrop extends FlxSprite
 		newRect.setSize(frameWidth * Math.abs(scale.x), frameHeight * Math.abs(scale.y));
 		return newRect.getRotatedBounds(angle, scaledOrigin, newRect);
 	}
-	
+
 	function modMin(value:Float, step:Float, min:Float)
 	{
 		return value - Math.floor((value - min) / step) * step;
 	}
-	
+
 	function modMax(value:Float, step:Float, max:Float)
 	{
 		return value - Math.ceil((value - max) / step) * step;
 	}
-	
+
 	function regenGraphic(camera:FlxCamera)
 	{
 		// The distance between repeated sprites, in screen space
-		var tileSize = FlxPoint.get(
-			(frameWidth  + spacing.x) * scale.x,
-			(frameHeight + spacing.y) * scale.y
-		);
-		
+		var tileSize = FlxPoint.get((frameWidth + spacing.x) * scale.x, (frameHeight + spacing.y) * scale.y);
+
 		var view = camera.getViewRect();
 		var tilesX = 1;
 		var tilesY = 1;
 		if (repeatAxes != NONE)
 		{
-			inline function min (a:Int, b:Int):Int return a < b ? a : b;
+			inline function min(a:Int, b:Int):Int
+				return a < b ? a : b;
 			switch (blitMode)
 			{
-				case AUTO | SPLIT (1):
-					if (repeatAxes.x) tilesX = Math.ceil(view.width  / tileSize.x) + 1;
-					if (repeatAxes.y) tilesY = Math.ceil(view.height / tileSize.y) + 1;
+				case AUTO | SPLIT(1):
+					if (repeatAxes.x)
+						tilesX = Math.ceil(view.width / tileSize.x) + 1;
+					if (repeatAxes.y)
+						tilesY = Math.ceil(view.height / tileSize.y) + 1;
 				case MAX_TILES(1) | MAX_TILES_XY(1, 1):
 				case MAX_TILES(max):
-					if (repeatAxes.x) tilesX = min(max, Math.ceil(view.width  / tileSize.x) + 1);
-					if (repeatAxes.y) tilesY = min(max, Math.ceil(view.height / tileSize.y) + 1);
+					if (repeatAxes.x)
+						tilesX = min(max, Math.ceil(view.width / tileSize.x) + 1);
+					if (repeatAxes.y)
+						tilesY = min(max, Math.ceil(view.height / tileSize.y) + 1);
 				case MAX_TILES_XY(maxX, maxY):
-					if (repeatAxes.x) tilesX = min(maxX, Math.ceil(view.width  / tileSize.x) + 1);
-					if (repeatAxes.y) tilesY = min(maxY, Math.ceil(view.height / tileSize.y) + 1);
+					if (repeatAxes.x)
+						tilesX = min(maxX, Math.ceil(view.width / tileSize.x) + 1);
+					if (repeatAxes.y)
+						tilesY = min(maxY, Math.ceil(view.height / tileSize.y) + 1);
 				case SPLIT(portions):
-					if (repeatAxes.x) tilesX = repeatAxes.x ? Math.ceil(view.width  / tileSize.x / portions + 1) : 1;
-					if (repeatAxes.y) tilesY = repeatAxes.y ? Math.ceil(view.height / tileSize.y / portions + 1) : 1;
+					if (repeatAxes.x)
+						tilesX = repeatAxes.x ? Math.ceil(view.width / tileSize.x / portions + 1) : 1;
+					if (repeatAxes.y)
+						tilesY = repeatAxes.y ? Math.ceil(view.height / tileSize.y / portions + 1) : 1;
 			}
 		}
-		
+
 		view.put();
-		
+
 		if (matchPrevDrawParams(tilesX, tilesY))
 		{
 			tileSize.put();
 			return;
 		}
 		setDrawParams(tilesX, tilesY);
-		
+
 		_blitOffset.set(0, 0);
 		var graphicSizeX = Math.ceil(tilesX * tileSize.x);
 		var graphicSizeY = Math.ceil(tilesY * tileSize.y);
@@ -452,7 +454,7 @@ class FlxBackdrop extends FlxSprite
 				graphicSizeX = Math.ceil(screenBounds.width);
 				_blitOffset.x = screenBounds.x - screenPos.x;
 			}
-			
+
 			if (!repeatAxes.y)
 			{
 				graphicSizeY = Math.ceil(screenBounds.height);
@@ -461,19 +463,19 @@ class FlxBackdrop extends FlxSprite
 			screenBounds.put();
 			screenPos.put();
 		}
-		
+
 		if (_blitGraphic == null || (_blitGraphic.width != graphicSizeX || _blitGraphic.height != graphicSizeY))
 		{
 			_blitGraphic = FlxG.bitmap.create(graphicSizeX, graphicSizeY, 0x0, true);
 		}
-		
+
 		var pixels = _blitGraphic.bitmap;
 		pixels.lock();
-		
+
 		pixels.fillRect(pixels.rect, FlxColor.TRANSPARENT);
 		animation.frameIndex = 0;
 		calcFrame(true);
-		
+
 		_matrix.identity();
 		_matrix.translate(-origin.x, -origin.y);
 		_matrix.scale(scale.x, scale.y);
@@ -483,11 +485,11 @@ class FlxBackdrop extends FlxSprite
 			if (angle != 0)
 				_matrix.rotateWithTrig(_cosAngle, _sinAngle);
 		}
-		
+
 		_matrix.translate(origin.x, origin.y);
 		_matrix.translate(-_blitOffset.x, -_blitOffset.y);
 		_point.set(_matrix.tx, _matrix.ty);
-		
+
 		// draw extra tiles on the edge in case the image protrudes past the tile
 		// TODO: Use 0 buffer when angle is multiple of 90 with centered origin
 		final bufferX = repeatAxes.x && angle != 0 ? 1 : 0;
@@ -501,36 +503,36 @@ class FlxBackdrop extends FlxSprite
 				pixels.draw(framePixels, _matrix);
 			}
 		}
-		
+
 		pixels.unlock();
-		
+
 		tileSize.put();
 	}
-	
+
 	inline function matchPrevDrawParams(tilesX:Int, tilesY:Int)
 	{
 		return _prevDrawParams.graphicKey == graphic.key
-			&& _prevDrawParams.tilesX     == tilesX
-			&& _prevDrawParams.tilesY     == tilesY
-			&& _prevDrawParams.scaleX     == scale.x
-			&& _prevDrawParams.scaleY     == scale.y
-			&& _prevDrawParams.spacingX   == spacing.x
-			&& _prevDrawParams.spacingY   == spacing.y
+			&& _prevDrawParams.tilesX == tilesX
+			&& _prevDrawParams.tilesY == tilesY
+			&& _prevDrawParams.scaleX == scale.x
+			&& _prevDrawParams.scaleY == scale.y
+			&& _prevDrawParams.spacingX == spacing.x
+			&& _prevDrawParams.spacingY == spacing.y
 			&& _prevDrawParams.repeatAxes == repeatAxes
-			&& _prevDrawParams.angle      == angle;
+			&& _prevDrawParams.angle == angle;
 	}
-	
+
 	inline function setDrawParams(tilesX:Int, tilesY:Int)
 	{
 		_prevDrawParams.graphicKey = graphic.key;
-		_prevDrawParams.tilesX     = tilesX;
-		_prevDrawParams.tilesY     = tilesY;
-		_prevDrawParams.scaleX     = scale.x;
-		_prevDrawParams.scaleY     = scale.y;
-		_prevDrawParams.spacingX   = spacing.x;
-		_prevDrawParams.spacingY   = spacing.y;
+		_prevDrawParams.tilesX = tilesX;
+		_prevDrawParams.tilesY = tilesY;
+		_prevDrawParams.scaleX = scale.x;
+		_prevDrawParams.scaleY = scale.y;
+		_prevDrawParams.spacingX = spacing.x;
+		_prevDrawParams.spacingY = spacing.y;
 		_prevDrawParams.repeatAxes = repeatAxes;
-		_prevDrawParams.angle      = angle;
+		_prevDrawParams.angle = angle;
 	}
 }
 
@@ -540,17 +542,17 @@ enum BackdropBlitMode
 	 * Not implemented yet.
 	 */
 	AUTO;
-	
+
 	/**
 	 * Blits a bitmap as big as the specified number of x and y tiles and repeats that.
 	 */
 	MAX_TILES_XY(x:Int, y:Int);
-	
+
 	/**
 	 * Blits a bitmap as big as the specified number of tiles and repeats that.
 	 */
 	MAX_TILES(tiles:Int);
-	
+
 	/**
 	 * Blits enough tiles to cover the screen in multiple draws, for example, if the camera is 10x8
 	 * tiles big, SPLIT(2) will draw a blit target 5x4 tiles large and draw it 2x2 times to cover the
@@ -559,7 +561,8 @@ enum BackdropBlitMode
 	SPLIT(portions:Int);
 }
 
-typedef BackdropDrawParams = {
+typedef BackdropDrawParams =
+{
 	graphicKey:String,
 	tilesX:Int,
 	tilesY:Int,

--- a/flixel/addons/display/FlxSliceSprite.hx
+++ b/flixel/addons/display/FlxSliceSprite.hx
@@ -215,7 +215,7 @@ class FlxSliceSprite extends FlxStrip
 
 		var centerX = topLeft.width;
 		var centerY = topLeft.height;
-		
+
 		var bdSize:FlxPoint = helperBdSize.set(graphic.width, graphic.height);
 		var dst:FlxPoint = helperDst;
 		var slice:FlxRect = helperRect;
@@ -223,7 +223,7 @@ class FlxSliceSprite extends FlxStrip
 
 		var numHorizontal:Int = Math.ceil((_snappedWidth - topLeft.width - topRight.width) / topMiddle.width);
 		var numVertical:Int = Math.ceil((_snappedHeight - topLeft.height - bottomLeft.height) / middleLeft.height);
-	
+
 		vertices = new DrawData<Float>();
 		uvtData = new DrawData<Float>();
 		indices = new DrawData<Int>();
@@ -641,7 +641,7 @@ class FlxSliceSprite extends FlxStrip
 	{
 		if (Value != fillCenter)
 			regen = true;
-		
+
 		return fillCenter = Value;
 	}
 

--- a/flixel/addons/editors/spine/FlxSpine.hx
+++ b/flixel/addons/editors/spine/FlxSpine.hx
@@ -93,6 +93,8 @@ class FlxSpine extends FlxSprite
 	 * @param	Y				The initial Y position of the sprite.
 	 * @param	Width			The maximum width of this sprite (avoid very large sprites since they are performance intensive).
 	 * @param	Height			The maximum height of this sprite (avoid very large sprites since they are performance intensive).
+	 * @param	OffsetX			
+	 * @param	OffsetY			
 	 * @param	renderMeshes	If true, then graphic will be rendered with drawTriangles(), if false (by default), then it will be rendered with drawTiles().
 	 */
 	public function new(skeletonData:SkeletonData, X:Float = 0, Y:Float = 0, Width:Float = 0, Height:Float = 0, OffsetX:Float = 0, OffsetY:Float = 0,

--- a/flixel/addons/editors/tiled/TiledGroupLayer.hx
+++ b/flixel/addons/editors/tiled/TiledGroupLayer.hx
@@ -2,7 +2,6 @@ package flixel.addons.editors.tiled;
 
 import flixel.addons.editors.tiled.TiledLayer.TiledLayerType;
 import flixel.util.FlxColor;
-
 #if haxe4
 import haxe.xml.Access;
 #else
@@ -17,8 +16,9 @@ import haxe.xml.Fast as Access;
 class TiledGroupLayer extends TiledLayer
 {
 	public var layers:Array<TiledLayer> = [];
+
 	var layerMap:Map<String, TiledLayer> = new Map<String, TiledLayer>();
-	
+
 	public function new(source:Access, parent:TiledMap, noLoadHash:Map<String, Bool>)
 	{
 		super(source, parent);
@@ -29,10 +29,10 @@ class TiledGroupLayer extends TiledLayer
 	function loadLayers(source:Access, parent:TiledMap, noLoadHash:Map<String, Bool>):Void
 	{
 		for (el in source.elements)
-		{	
+		{
 			if (el.has.name && noLoadHash.exists(el.att.name))
 				continue;
-			
+
 			var layer:TiledLayer = switch (el.name.toLowerCase())
 			{
 				case "group": new TiledGroupLayer(el, parent, noLoadHash);
@@ -41,7 +41,7 @@ class TiledGroupLayer extends TiledLayer
 				case "imagelayer": new TiledImageLayer(el, parent);
 				case _: null;
 			}
-			
+
 			if (layer != null)
 			{
 				layers.push(layer);
@@ -51,7 +51,7 @@ class TiledGroupLayer extends TiledLayer
 	}
 
 	public function getLayer(name:String):TiledLayer
-	{	
+	{
 		return layerMap.get(name);
 	}
 }

--- a/flixel/addons/effects/FlxClothSprite.hx
+++ b/flixel/addons/effects/FlxClothSprite.hx
@@ -109,12 +109,13 @@ class FlxClothSprite extends FlxSprite
 	 * Creates a FlxClothSprite at a specified position with a specified one-frame graphic.
 	 * If none is provided, a 16x16 image of the HaxeFlixel logo is used.
 	 *
-	 * @param	X				The initial X position of the sprite.
-	 * @param	Y				The initial Y position of the sprite.
-	 * @param	SimpleGraphic	The graphic you want to display (OPTIONAL - for simple stuff only, do NOT use for animated images!).
-	 * @param	Columns			Number of columns of the created mesh.
-	 * @param	Rows			Number of rows of the created mesh.
-	 * @param	PinnedSide		The pinned side that points are not affected by wind or velocity. Use UP, DOWN, LEFT, RIGHT, NONE, ANY, etc.
+	 * @param	X					The initial X position of the sprite.
+	 * @param	Y					The initial Y position of the sprite.
+	 * @param	SimpleGraphic		The graphic you want to display (OPTIONAL - for simple stuff only, do NOT use for animated images!).
+	 * @param	Columns				Number of columns of the created mesh.
+	 * @param	Rows				Number of rows of the created mesh.
+	 * @param	PinnedSide			The pinned side that points are not affected by wind or velocity. Use UP, DOWN, LEFT, RIGHT, NONE, ANY, etc.
+	 * @param	CrossingConstraints
 	 */
 	public function new(?X:Float = 0, ?Y:Float = 0, ?SimpleGraphic:FlxGraphicAsset, Columns:Int = 0, Rows:Int = 0, PinnedSide:FlxDirectionFlags = UP,
 			CrossingConstraints:Bool = false)

--- a/flixel/addons/effects/chainable/FlxEffectSprite.hx
+++ b/flixel/addons/effects/chainable/FlxEffectSprite.hx
@@ -76,7 +76,7 @@ class FlxEffectSprite extends FlxSprite
 	/**
 	 * Call this function to figure out the on-screen position of the object.
 	 *
-	 * @param	Point		Takes a FlxPoint object and assigns the post-scrolled X and Y values of this object to it.
+	 * @param	point		Takes a FlxPoint object and assigns the post-scrolled X and Y values of this object to it.
 	 * @param	Camera		Specify which game camera you want.  If null getScreenPosition() will just grab the first global camera.
 	 * @return	The Point you passed in, or a new Point if you didn't pass one, containing the screen X and Y position of this object.
 	 */

--- a/flixel/addons/effects/chainable/FlxOutlineEffect.hx
+++ b/flixel/addons/effects/chainable/FlxOutlineEffect.hx
@@ -77,8 +77,8 @@ class FlxOutlineEffect implements IFlxEffect
 	 * @param	Mode		Which Mode you would like to use for the effect. FAST = Optimized using only 4 draw calls, NORMAL = Outline on all 8 sides, PIXEL_BY_PIXEL = Surround every pixel (can affect performance).
 	 * @param	Color		Color of the outline.
 	 * @param	Thickness	Outline thickness in pixels.
-	 * @param	Quality 	Outline quality - # of iterations to use when drawing. 0:just 1, 1:equal number to Thickness. Not used with PIXEL_BY_PIXEL mode.
 	 * @param	Threshold	Alpha sensitivity, only used with PIXEL_BY_PIXEL mode.
+	 * @param	Quality 	Outline quality - # of iterations to use when drawing. 0:just 1, 1:equal number to Thickness. Not used with PIXEL_BY_PIXEL mode.
 	 */
 	public function new(?Mode:FlxOutlineMode, Color:FlxColor = FlxColor.WHITE, Thickness:Int = 1, Threshold:Int = 0, Quality:Float = 1)
 	{

--- a/flixel/addons/effects/chainable/FlxTrailEffect.hx
+++ b/flixel/addons/effects/chainable/FlxTrailEffect.hx
@@ -69,6 +69,7 @@ class FlxTrailEffect implements IFlxEffect
 	/**
 	 * Creates a trail effect.
 	 *
+	 * @param	Target			The FlxEffectSprite the trail is attached to.
 	 * @param	Length			The amount of trail images to create.
 	 * @param	Alpha			The alpha value for the first trailsprite.
 	 * @param	FramesDelay		How many frames wait until next trail updated.

--- a/flixel/addons/nape/FlxNapeSprite.hx
+++ b/flixel/addons/nape/FlxNapeSprite.hx
@@ -1,8 +1,8 @@
 package flixel.addons.nape;
 
 import flixel.FlxSprite;
-import flixel.system.FlxAssets;
 import flixel.math.FlxAngle;
+import flixel.system.FlxAssets;
 import nape.geom.Vec2;
 import nape.phys.Body;
 import nape.phys.BodyType;

--- a/flixel/addons/nape/FlxNapeVelocity.hx
+++ b/flixel/addons/nape/FlxNapeVelocity.hx
@@ -46,6 +46,7 @@ class FlxNapeVelocity
 	 * Timings are approximate due to the way Flash timers work, and irrespective of SWF frame rate. Allow for a variance of +- 50ms.
 	 * The source object doesn't stop moving automatically should it ever reach the destination coordinates.
 	 * @param	Source			The FlxNapeSprite to move
+	 * @param	Touch			The FlxTouch where the source object will move to
 	 * @param	Speed			The speed it will move, in pixels per second (default is 100 pixels/sec)
 	 */
 	public static inline function moveTowardsTouch(Source:FlxNapeSprite, Touch:FlxTouch, Speed:Float = 100):Void

--- a/flixel/addons/plugin/FlxScrollingText.hx
+++ b/flixel/addons/plugin/FlxScrollingText.hx
@@ -241,7 +241,7 @@ class FlxScrollingText extends FlxBasic
 	 * Note: If the text is set to only scroll when on-screen, but if off-screen when this is called, it will still return true.
 	 *
 	 * @param	source	The FlxSprite to check for scrolling on.
-	 * @return	Bool true is the FlxSprite was found and is scrolling, otherwise false
+	 * @return	True if the FlxSprite was found and is scrolling, otherwise false
 	 */
 	public static function isScrolling(source:FlxSprite):Bool
 	{
@@ -257,7 +257,7 @@ class FlxScrollingText extends FlxBasic
 	 * Removes an FlxSprite from the Text Scroller. Note that it doesn't restore the sprite bitmapData.
 	 *
 	 * @param	source	The FlxSprite to remove scrolling for.
-	 * @return	Bool	true if the FlxSprite was removed, otherwise false.
+	 * @return	True if the FlxSprite was removed, otherwise false.
 	 */
 	public static function remove(source:FlxSprite):Bool
 	{

--- a/flixel/addons/plugin/control/FlxControl.hx
+++ b/flixel/addons/plugin/control/FlxControl.hx
@@ -30,6 +30,7 @@ class FlxControl extends FlxBasic
 	 * @param	Sprite			The FlxSprite you want this class to control. It can only control one FlxSprite at once.
 	 * @param	MovementType	Set to either MOVEMENT_INSTANT or MOVEMENT_ACCELERATES
 	 * @param	StoppingType	Set to STOPPING_INSTANT, STOPPING_DECELERATES or STOPPING_NEVER
+	 * @param	Player			An optional ID for the player using these controls; using an ID of 1-4 will allow quick reference via `FlxControl.player{ID}`
 	 * @param	UpdateFacing	If true it sets the FlxSprite.facing value to the direction pressed (default false)
 	 * @param	EnableArrowKeys	If true it will enable all arrow keys (default) - see setCursorControl for more fine-grained control
 	 * @return	The new FlxControlHandler
@@ -77,7 +78,7 @@ class FlxControl extends FlxBasic
 	 * Removes a FlxControlHandler
 	 *
 	 * @param	ControlHandler	The FlxControlHandler to delete
-	 * @return	Boolean	true if the FlxControlHandler was removed, otherwise false.
+	 * @return	True if the FlxControlHandler was removed, otherwise false.
 	 */
 	public static function remove(ControlHandler:FlxControlHandler):Bool
 	{

--- a/flixel/addons/plugin/control/FlxControlHandler.hx
+++ b/flixel/addons/plugin/control/FlxControlHandler.hx
@@ -1267,10 +1267,10 @@ class FlxControlHandler
 	 * Enables WASD controls. Can be set on a per-key basis. Useful if you only want to allow a few keys.
 	 * For example in a Space Invaders game you'd only enable LEFT and RIGHT.
 	 *
-	 * @param	allowUp		Enable the up (W) key
-	 * @param	allowDown	Enable the down (S) key
-	 * @param	allowLeft	Enable the left (A) key
-	 * @param	allowRight	Enable the right (D) key
+	 * @param	AllowUp		Enable the up (W) key
+	 * @param	AllowDown	Enable the down (S) key
+	 * @param	AllowLeft	Enable the left (A) key
+	 * @param	AllowRight	Enable the right (D) key
 	 */
 	public function setWASDControl(AllowUp:Bool = true, AllowDown:Bool = true, AllowLeft:Bool = true, AllowRight:Bool = true):Void
 	{

--- a/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
+++ b/flixel/addons/plugin/screengrab/FlxScreenGrab.hx
@@ -61,7 +61,7 @@ class FlxScreenGrab extends FlxBasic
 	 * Specify which key will capture a screen shot. Use the String value of the key in the same way FlxG.keys does (so "F1" for example)
 	 * Optionally save the image to a file immediately. This uses the file systems "Save as" dialog window and pauses your game during the process.
 	 *
-	 * @param	Key			The key(s) you press to capture the screen (i.e. [F1, SPACE])
+	 * @param	Keys		The key(s) you press to capture the screen (i.e. [F1, SPACE])
 	 * @param	SaveToFile	If true it will immediately encodes the grab to a PNG and open a "Save As" dialog window when the hotkey is pressed
 	 * @param	HideMouse	If true the mouse will be hidden before capture and displayed afterwards when the hotkey is pressed
 	 */
@@ -88,7 +88,7 @@ class FlxScreenGrab extends FlxBasic
 	 * @param	CaptureRegion	A Rectangle area to capture. This over-rides that set by "defineCaptureRegion". If neither are set the full SWF size is used.
 	 * @param	SaveToFile		Boolean If set to true it will immediately encode the grab to a PNG and open a "Save As" dialog window
 	 * @param	HideMouse		Boolean If set to true the mouse will be hidden before capture and displayed again afterwards
-	 * @return	Bitmap			The screen grab as a Flash Bitmap image
+	 * @return	The screen grab as a Flash Bitmap image
 	 */
 	public static function grab(?CaptureRegion:Rectangle, ?SaveToFile:Bool = false, HideMouse:Bool = false):Bitmap
 	{

--- a/flixel/addons/plugin/taskManager/FlxTaskManager.hx
+++ b/flixel/addons/plugin/taskManager/FlxTaskManager.hx
@@ -167,7 +167,7 @@ class FlxTaskManager extends FlxBasic
 	 * Method-task for a pause between tasks
 	 *
 	 * @param	Delay	 Delay
-	 * @return	Returns true when the task is completed
+	 * @return	True if the task completed successfully, false otherwise
 	 */
 	function taskPause(Delay:Float):Bool
 	{
@@ -186,7 +186,7 @@ class FlxTaskManager extends FlxBasic
 	 * Adds the specified object to the end of the list
 	 *
 	 * @param	Task	The FlxTask to be added.
-	 * @return	Returns a pointer to the added FlxTask.
+	 * @return	A pointer to the added FlxTask.
 	 */
 	function push(Task:FlxTask):FlxTask
 	{
@@ -218,7 +218,7 @@ class FlxTaskManager extends FlxBasic
 	 * Adds task to the top of task list
 	 *
 	 * @param	Task	The FlxTask to be added.
-	 * @return	Returns a pointer to the added FlxTask
+	 * @return	A pointer to the added FlxTask.
 	 */
 	function unshift(Task:FlxTask):FlxTask
 	{

--- a/flixel/addons/text/FlxTextField.hx
+++ b/flixel/addons/text/FlxTextField.hx
@@ -22,6 +22,7 @@ class FlxTextField extends FlxText
 	 * @param	Y				The Y position of the text.
 	 * @param	Width			The width of the text object (height is determined automatically).
 	 * @param	Text			The actual text you would like to display initially.
+	 * @param	Size			The font size for this text object.
 	 * @param	EmbeddedFont	Whether this text field uses embedded fonts or not
 	 */
 	public function new(X:Float, Y:Float, Width:Int, ?Text:String, Size:Int = 8, EmbeddedFont:Bool = true)

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -283,7 +283,6 @@ class FlxTypeText extends FlxText
 	 * @param	ForceRestart	Whether or not to start this animation over if currently animating; false by default.
 	 * @param	SkipKeys		An array of keys as string values (e.g. `[FlxKey.SPACE, FlxKey.L]`) that will advance the text. Can also be set separately.
 	 * @param	Callback		An optional callback function, to be called when the erasing animation is complete.
-	 * @param	Params			Optional parameters to pass to the callback function.
 	 */
 	public function erase(?Delay:Float, ForceRestart:Bool = false, ?SkipKeys:Array<FlxKey>, ?Callback:Void->Void):Void
 	{

--- a/flixel/addons/tile/FlxCaveGenerator.hx
+++ b/flixel/addons/tile/FlxCaveGenerator.hx
@@ -40,7 +40,7 @@ class FlxCaveGenerator
 	 * @param	Rows					Number of rows for the matrix
 	 * @param	SmoothingIterations 	How many times do you want to "smooth" the caev - the higher the smoother, but slower
 	 * @param	WallRatio 				Chance for a tile to become a wall - the closer the value is to 1.0, the more walls there are
-	 * @return	Returns a matrix of a cave!
+	 * @return	A matrix of a cave!
 	 */
 	public static function generateCaveMatrix(Columns:Int, Rows:Int, SmoothingIterations:Int = 6, WallRatio:Float = 0.5):Array<Array<Int>>
 	{
@@ -92,7 +92,7 @@ class FlxCaveGenerator
 	 *
 	 * @param	Columns 	Number of columns for the matrix
 	 * @param	Rows		Number of rows for the matrix
-	 * @return 	Spits out a matrix that is columns * rows big, initiated with zeros
+	 * @return 	A matrix that is columns * rows big, initiated with zeros
 	 */
 	static function generateInitialMatrix(Columns:Int, Rows:Int):Array<Array<Int>>
 	{

--- a/flixel/addons/tile/FlxRayCastTilemap.hx
+++ b/flixel/addons/tile/FlxRayCastTilemap.hx
@@ -27,7 +27,7 @@ class FlxRayCastTilemap extends FlxTilemap
 	 * @param 	Result   			Where the resulting point is stored, in (x,y) coordinates
 	 * @param 	ResultInTiles  		A point containing the tile that was hit, in tile coordinates (optional)
 	 * @param 	MaxTilesToCheck 	The maximum number of tiles you want the ray to pass. -1 means go across the entire tilemap. Only change this if you know what you're doing!
-	 * @return   true if hit a filled tile, false if it hit the end of the tilemap
+	 * @return   True if hit a filled tile, false if it hit the end of the tilemap
 	 *
 	 */
 	public function rayCast(Start:FlxPoint, Direction:FlxPoint, ?Result:FlxPoint, ?ResultInTiles:FlxPoint, MaxTilesToCheck:Int = -1):Bool

--- a/flixel/addons/tile/FlxTileSpecial.hx
+++ b/flixel/addons/tile/FlxTileSpecial.hx
@@ -159,6 +159,7 @@ class FlxTileSpecial extends FlxBasic
 	 * Add an animation to this special tile
 	 * @param	tiles		An array with the tilesetID of each frame
 	 * @param	frameRate	The speed of the animation in frames per second (Default: 30)
+	 * @param	framesData	
 	 */
 	public function addAnimation(tiles:Array<Int>, frameRate:Float = 30, ?framesData:Array<AnimParams>):Void
 	{
@@ -176,8 +177,6 @@ class FlxTileSpecial extends FlxBasic
 
 	/**
 	 * Calculates and return the matrix
-	 * @param	width	the tile width
-	 * @param	height	the tile height
 	 * @return	The matrix calculated
 	 */
 	public function getMatrix():FlxMatrix

--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -508,7 +508,7 @@ class FlxTilemapExt extends FlxTilemap
 	 * Internal helper functions for comparing a tile to the slope arrays to see if a tile should be treated as STEEP or GENTLE slope.
 	 *
 	 * @param 	TileIndex	The Tile Index number of the Tile you want to check.
-	 * @return	Returns true if the tile is listed in one of the slope arrays. Otherwise returns false.
+	 * @return	True if the tile is listed in one of the slope arrays. Otherwise false.
 	 */
 	function checkThickGentle(TileIndex:Int):Bool
 	{
@@ -874,7 +874,7 @@ class FlxTilemapExt extends FlxTilemap
 	 * Internal helper function for comparing a tile to the slope arrays to see if a tile should be treated as a slope.
 	 *
 	 * @param 	TileIndex	The Tile Index number of the Tile you want to check.
-	 * @return	Returns true if the tile is listed in one of the slope arrays. Otherwise returns false.
+	 * @return	True if the tile is listed in one of the slope arrays. Otherwise false.
 	 */
 	function checkArrays(TileIndex:Int):Bool
 	{

--- a/flixel/addons/util/FlxFSM.hx
+++ b/flixel/addons/util/FlxFSM.hx
@@ -16,23 +16,23 @@ class FlxFSMState<T> implements IFlxDestroyable
 	/**
 	 * Called when state becomes active.
 	 *
-	 * @param	Owner	The object the state controls
-	 * @param	FSM		The FSM instance this state belongs to. Used for changing the state to another.
+	 * @param	owner	The object the state controls
+	 * @param	fsm		The FSM instance this state belongs to. Used for changing the state to another.
 	 */
 	public function enter(owner:T, fsm:FlxFSM<T>):Void {}
 
 	/**
 	 * Called every update loop.
 	 *
-	 * @param	Owner	The object the state controls
-	 * @param	FSM		The FSM instance this state belongs to. Used for changing the state to another.
+	 * @param	owner	The object the state controls
+	 * @param	fsm		The FSM instance this state belongs to. Used for changing the state to another.
 	 */
 	public function update(elapsed:Float, owner:T, fsm:FlxFSM<T>):Void {}
 
 	/**
 	 * Called when the state becomes inactive.
 	 *
-	 * @param	Owner	The object the state controls
+	 * @param	owner	The object the state controls
 	 */
 	public function exit(owner:T):Void {}
 
@@ -42,7 +42,7 @@ class FlxFSMState<T> implements IFlxDestroyable
 /**
  * Helper typedef for FlxExtendedFSM's pools
  */
-typedef StatePool<T> = Map<String, FlxPool<FlxFSMState<T>>>
+typedef StatePool<T> = Map<String, FlxPool<FlxFSMState<T>>>;
 
 /**
  * A generic Finite-state machine implementation.
@@ -264,7 +264,7 @@ class FlxFSMStack<T> extends FlxFSMStackSignal implements IFlxDestroyable
 
 	/**
 	 * Locks the specified FSM for the duration of the update loop
-	 * @param	name
+	 * @param	name	The name of the FSM to lock
 	 */
 	public function lock(name:String):Void
 	{
@@ -296,7 +296,7 @@ class FlxFSMStack<T> extends FlxFSMStackSignal implements IFlxDestroyable
 
 	/**
 	 * Adds the FSM to the front of the stack
-	 * @param	FSM
+	 * @param	FSM		The FSM to add
 	 */
 	public function unshift(FSM:FlxFSM<T>)
 	{
@@ -325,7 +325,7 @@ class FlxFSMStack<T> extends FlxFSMStackSignal implements IFlxDestroyable
 
 	/**
 	 * Adds the FSM to the end of the stack
-	 * @param	FSM
+	 * @param	FSM		The FSM to add
 	 */
 	public function push(FSM:FlxFSM<T>)
 	{
@@ -355,7 +355,7 @@ class FlxFSMStack<T> extends FlxFSMStackSignal implements IFlxDestroyable
 
 	/**
 	 * Removes the FSM from the stack and destroys it
-	 * @param	The removed FSM
+	 * @param	FSM		The FSM to remove
 	 */
 	public function remove(FSM:FlxFSM<T>)
 	{
@@ -372,7 +372,7 @@ class FlxFSMStack<T> extends FlxFSMStackSignal implements IFlxDestroyable
 
 	/**
 	 * Removes the FSM with given name from the stack and destroys it
-	 * @param	The removed FSM
+	 * @param	name	The name of the FSM to remove
 	 */
 	public function removeByName(name:String)
 	{
@@ -448,7 +448,8 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Polls the transition table for active states
-	 * @param	FSM	The FlxFSMState the table belongs to
+	 * @param	currentState	The class of the current FlxFSMState
+	 * @param	owner			The FlxFSMState the table belongs to
 	 * @return	The state that should become or remain active.
 	 */
 	public function poll(currentState:Class<FlxFSMState<T>>, owner:T):Class<FlxFSMState<T>>
@@ -498,9 +499,9 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Adds a transition condition to the table.
-	 * @param	From	The state the condition applies to
-	 * @param	To		The state to transition
-	 * @param	Condition	Function that returns true if the transition conditions are met
+	 * @param	from		The state the condition applies to
+	 * @param	to			The state to transition
+	 * @param	condition	Function that returns true if the transition conditions are met
 	 */
 	public function add(from:Class<FlxFSMState<T>>, to:Class<FlxFSMState<T>>, condition:T->Bool)
 	{
@@ -517,8 +518,8 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Adds a global transition condition to the table.
-	 * @param	To		The state to transition
-	 * @param	Condition	Function that returns true if the transition conditions are met
+	 * @param	to		The state to transition
+	 * @param	condition	Function that returns true if the transition conditions are met
 	 */
 	public function addGlobal(to:Class<FlxFSMState<T>>, condition:T->Bool)
 	{
@@ -546,7 +547,7 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Sets the starting State
-	 * @param	With
+	 * @param	with	The class of the starting State
 	 */
 	public function start(with:Class<FlxFSMState<T>>)
 	{
@@ -556,8 +557,8 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Replaces given state class with another.
-	 * @param	Target			State class to replace
-	 * @param	Replacement		State class to replace with
+	 * @param	target			State class to replace
+	 * @param	replacement		State class to replace with
 	 */
 	public function replace(target:Class<FlxFSMState<T>>, replacement:Class<FlxFSMState<T>>)
 	{
@@ -587,9 +588,9 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Removes a transition condition from the table
-	 * @param	From	From State
-	 * @param	To		To State
-	 * @param	Condition	Condition function
+	 * @param	from	From State
+	 * @param	to		To State
+	 * @param	condition	Condition function
 	 * @return	True when removed, false if not in table
 	 */
 	public function remove(?from:Class<FlxFSMState<T>>, ?to:Class<FlxFSMState<T>>, ?condition:Null<T->Bool>)
@@ -637,9 +638,9 @@ class FlxFSMTransitionTable<T>
 
 	/**
 	 * Tells if the table contains specific transition or transitions.
-	 * @param	From	From State
-	 * @param	To		To State
-	 * @param	Condition	Condition function
+	 * @param	from	From State
+	 * @param	to		To State
+	 * @param	condition	Condition function
 	 * @return	True if match found
 	 */
 	public function hasTransition(?from:Class<FlxFSMState<T>>, ?to:Class<FlxFSMState<T>>, ?condition:Null<T->Bool>):Bool

--- a/flixel/addons/util/FlxScene.hx
+++ b/flixel/addons/util/FlxScene.hx
@@ -476,7 +476,7 @@ class FlxScene
 	/**
 	 * Gets a specific object by id.
 	 *
-	 * @param 	Id 	Constant name.
+	 * @param 	id 	Constant name.
 	 * @return
 	 */
 	public function object(id:String):Dynamic
@@ -492,7 +492,7 @@ class FlxScene
 	/**
 	 * Helper function to parse Booleans from String to Bool
 	 *
-	 * @param Value 	String value
+	 * @param value 	String value
 	 */
 	function parseBool(value:String):Bool
 	{

--- a/flixel/addons/weapon/FlxWeapon.hx
+++ b/flixel/addons/weapon/FlxWeapon.hx
@@ -38,7 +38,7 @@ import flixel.util.helpers.FlxRange;
  * TODO: Bullet trails - blur FX style and Missile Command "draw lines" style? (could be another FX plugin)
  * TODO: Homing Missiles
  * TODO: Bullet uses random sprite from sprite sheet (for rainbow style bullets), or cycles through them in sequence?
- * TODO: Some Weapon base classes like shotgun, lazer, etc?
+ * TODO: Some Weapon base classes like shotgun, laser, etc?
  */
 typedef FlxWeapon = FlxTypedWeapon<FlxBullet>;
 
@@ -151,8 +151,8 @@ class FlxTypedWeapon<TBullet:FlxBullet>
 	 * You should call one of the makeBullet functions to visually create the bullets.
 	 * Then either use setDirection with fire() or one of the fireAt functions to launch them.
 	 *
-	 * @param	Name		The name of your weapon (i.e. "lazer" or "shotgun"). For your internal reference really, but could be displayed in-game.
-	 * @param	BulletFactory	FlxWeapon uses this factory function to actually create a bullet
+	 * @param	name		The name of your weapon (i.e. "laser" or "shotgun"). For your internal reference really, but could be displayed in-game.
+	 * @param	bulletFactory	FlxWeapon uses this factory function to actually create a bullet
 	 * @param	fireFrom	enum that describes the weapon firing position, for Example Parent, Position.
 	 * @param	speedMode	enum that describes the bullets speed mode, for Example Velocity, Acceleration.
 	 */
@@ -171,10 +171,7 @@ class FlxTypedWeapon<TBullet:FlxBullet>
 	/**
 	 * Internal function that handles the actual firing of the bullets
 	 *
-	 * @param	Method
-	 * @param	X
-	 * @param	Y
-	 * @param	Target
+	 * @param	Mode	Mode to use for firing the bullet
 	 * @return	True if a bullet was fired or false if one wasn't available. The bullet last fired is stored in FlxWeapon.prevBullet
 	 */
 	function runFire(Mode:FlxWeaponFireMode):Bool
@@ -292,7 +289,7 @@ class FlxTypedWeapon<TBullet:FlxBullet>
 	 *
 	 * @param	point	The to be rotated point
 	 * @param	origin	The to be rotated around point. usually the origin of the parent flxsprite
-	 * @param	point	the current angle from of the origin. usually the parent angle.
+	 * @param	angle	the current angle from of the origin. usually the parent angle.
 	 * @return	The new rotated Point
 	 */
 	public function rotatePoints(point:FlxPoint, origin:FlxPoint, angle:Float):FlxPoint
@@ -373,7 +370,7 @@ class FlxTypedWeapon<TBullet:FlxBullet>
 	/**
 	 * Fires a bullet (if one is available) based on the given angle
 	 *
-	 * @param	Angle	The angle (in degrees) calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
+	 * @param	angle	The angle (in degrees) calculated in clockwise positive direction (down = 90 degrees positive, right = 0 degrees positive, up = 90 degrees negative)
 	 * @return	True if a bullet was fired or false if one wasn't available. A reference to the bullet fired is stored in FlxWeapon.currentBullet.
 	 */
 	public inline function fireFromAngle(angle:FlxBounds<Float>):Bool

--- a/include.xml
+++ b/include.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<project xmlns="http://lime.software/project/1.0.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://lime.software/project/1.0.2 http://lime.software/xsd/project-1.0.2.xsd">
+<project xmlns="http://lime.software/project/1.0.4" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://lime.software/project/1.0.4 http://lime.software/xsd/project-1.0.4.xsd">
 
 	<!-- This prevents a bug in neko where inlined functions exceed the max code length -->
 	<haxedef name="NAPE_NO_INLINE" if="neko" />


### PR DESCRIPTION
Did this because the parameters would not show their descriptions when hovered over if they were not written correctly in the doc comments.
Also removed redundant instances of "returns" from some "@return" tags.
*Also* inadvertantly ran the auto-format on some files after editing and saving them.