### PR TITLE
Add skipCallback to FlxTypeText

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -2,6 +2,8 @@ package flixel.addons.text;
 
 import flixel.FlxG;
 import flixel.input.keyboard.FlxKey;
+		if (FlxG.keys.justPressed.ENTER && isTalking)
+			skip();
 import flixel.math.FlxMath;
 import flixel.system.FlxAssets;
 import flixel.text.FlxText;
@@ -106,6 +108,11 @@ class FlxTypeText extends FlxText
 	 * This function is called when the message is done erasing, if that is enabled.
 	 */
 	public var eraseCallback:Void->Void;
+	
+	/**
+	* This function is called when the text is skipped.
+	*/
+	public var skipCallback:Void->Void;
 
 	/**
 	 * The text that will ultimately be displayed.
@@ -540,6 +547,9 @@ class FlxTypeText extends FlxText
 		{
 			_length = _finalText.length;
 		}
+		
+		if (skipCallback != null)
+			skipCallback();
 	}
 
 	function loadDefaultSound():Void

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -2,8 +2,6 @@ package flixel.addons.text;
 
 import flixel.FlxG;
 import flixel.input.keyboard.FlxKey;
-		if (FlxG.keys.justPressed.ENTER && isTalking)
-			skip();
 import flixel.math.FlxMath;
 import flixel.system.FlxAssets;
 import flixel.text.FlxText;

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -534,8 +534,10 @@ class FlxTypeText extends FlxText
 	 * Immediately finishes the animation. Called if any of the skipKeys is pressed.
 	 * Handy for custom skipping behaviour (for example with different inputs like mouse or gamepad).
 	 */
-	public function skip():Void
+	public function skip(?SkipCallback:Void->Void):Void
 	{
+		if (SkipCallback != null)
+			skipCallback = SkipCallback;
 		if (_erasing || _waiting)
 		{
 			_length = 0;


### PR DESCRIPTION
Makes it easier to do actions if the text is skipped. Current work arounds is to have a boolean that is set when e.g the user presses any of the skipKeys or when the text is complete.