### PR TITLE
Rework on the FlxNestedSprite

### DIFF
--- a/flixel/addons/display/FlxNestedSprite.hx
+++ b/flixel/addons/display/FlxNestedSprite.hx
@@ -99,7 +99,7 @@ class FlxNestedSprite extends FlxSprite
 	var relativeColorTransform:ColorTransform;
 
 	/**
-	 * This will remove this sprite entirely. Use kill() if you
+	 * WARNING: This will remove this sprite entirely. Use kill() if you
 	 * want to disable it temporarily only and reset() it later to revive it.
 	 * Used to clean up memory.
 	 */


### PR DESCRIPTION
While I was using FlxNestedSprite for a project, I noticed that it was very... uncomfortable
for example, you would need to use a relative variable, which you would use in case you added a child, making it very difficult to do stuff like `sprite.setPosition()` or even `sprite.x`! but instead `sprite.relativeX`. same goes with acceleration, scale, etc.

This should fix the inconvenience.