### PR TITLE
use enum over @:enum

### DIFF
--- a/flixel/addons/transition/FlxTransitionSprite.hx
+++ b/flixel/addons/transition/FlxTransitionSprite.hx
@@ -132,8 +132,7 @@ class FlxTransitionSprite extends FlxSprite
 	}
 }
 
-@:enum
-abstract TransitionStatus(Int)
+enum abstract TransitionStatus(Int)
 {
 	var IN = 0;
 	var OUT = 1;

--- a/flixel/addons/transition/TransitionData.hx
+++ b/flixel/addons/transition/TransitionData.hx
@@ -8,8 +8,7 @@ import flixel.util.FlxColor;
 import flixel.system.FlxAssets.FlxGraphicAsset;
 import flixel.util.FlxDestroyUtil.IFlxDestroyable;
 
-@:enum
-abstract TransitionType(String)
+enum abstract TransitionType(String)
 {
 	var NONE = "none";
 	var TILES = "tiles";


### PR DESCRIPTION
removes warning