### PR TITLE
Don’t render text you can’t see

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -547,4 +547,10 @@ class FlxTypeText extends FlxText
 		_sound.loadEmbedded(new TypeSound());
 		#end
 	}
+
+	override function regenGraphic(){
+		if (textField == null || !_regen || !isOnScreen())
+			return;
+		super.regenGraphic();
+	}
 }


### PR DESCRIPTION
This should prevent some lag issues happening, this has happened in a FNF mod I was making where the text would stat to go off screen and the frame rate would start to drop, so this PR should help prevent this from happening.

(Currently a draft since I can’t test it yet.)