### PR TITLE
FlxTypeText resetText to prefix

### DIFF
--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -318,7 +318,7 @@ class FlxTypeText extends FlxText
 	 */
 	public function resetText(Text:String):Void
 	{
-		text = "";
+		text = prefix;
 		_finalText = Text;
 		_typing = false;
 		_erasing = false;


### PR DESCRIPTION
fixes an issue where prefix is ignored when calling reset