### PR TITLE
Include a camera variable in FlxTransitionableState to play the transition on top of a different one

### DIFF
--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -36,7 +36,7 @@ class FlxTransitionableState extends FlxState
 
 	public static var skipNextTransIn:Bool = false;
 	public static var skipNextTransOut:Bool = false;
-	public static var transCam:FlxCamera = null;
+	public static var transCams:Array<FlxCamera> = null;
 
 	// beginning & ending transitions for THIS state:
 	public var transIn:TransitionData;
@@ -71,7 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
-		transCam = null;
+		transCam = [];
 		_onExit = null;
 	}
 
@@ -116,11 +116,11 @@ class FlxTransitionableState extends FlxState
 				return;
 			}
 
-			if (transCam == null)
-				transCam = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
+			if (transCams == null)
+				transCams = [flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1]];
 
 			var _trans = createTransition(transIn);
-			_trans.camera = transCam;
+			_trans.cameras = transCams;
 			_trans.setStatus(FULL);
 			openSubState(_trans);
 
@@ -137,11 +137,11 @@ class FlxTransitionableState extends FlxState
 		_onExit = OnExit;
 		if (hasTransOut)
 		{
-			if (transCam == null)
-				transCam = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
+			if (transCams == null)
+				transCams = [flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1]];
 
 			var _trans = createTransition(transOut);
-			_trans.camera = transCam;
+			_trans.cameras = transCams;
 			_trans.setStatus(EMPTY);
 			openSubState(_trans);
 

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -71,7 +71,6 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
-		transCams = null;
 		_onExit = null;
 	}
 
@@ -116,7 +115,7 @@ class FlxTransitionableState extends FlxState
 				return;
 			}
 
-			if (transCams == null)
+			if (transCams == null || transCams.length == 0)
 				transCams = [flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1]];
 
 			var _trans = createTransition(transIn);
@@ -137,7 +136,7 @@ class FlxTransitionableState extends FlxState
 		_onExit = OnExit;
 		if (hasTransOut)
 		{
-			if (transCams == null)
+			if (transCams == null || transCams.length == 0)
 				transCams = [flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1]];
 
 			var _trans = createTransition(transOut);

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -71,7 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
-		transCam = [];
+		transCam = null;
 		_onExit = null;
 	}
 

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -71,6 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
+		transCams = null;
 		_onExit = null;
 	}
 

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -36,7 +36,7 @@ class FlxTransitionableState extends FlxState
 
 	public static var skipNextTransIn:Bool = false;
 	public static var skipNextTransOut:Bool = false;
-	public static var transitionCamera:FlxCamera = null;
+	public static var transCam:FlxCamera = null;
 
 	// beginning & ending transitions for THIS state:
 	public var transIn:TransitionData;
@@ -71,7 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
-		transitionCamera = null;
+		transCam = null;
 		_onExit = null;
 	}
 
@@ -116,11 +116,11 @@ class FlxTransitionableState extends FlxState
 				return;
 			}
 
-			if (transitionCamera == null)
-				transitionCamera = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
+			if (transCam == null)
+				transCam = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
 
 			var _trans = createTransition(transIn);
-			_trans.camera = transitionCamera;
+			_trans.camera = transCam;
 			_trans.setStatus(FULL);
 			openSubState(_trans);
 
@@ -137,11 +137,11 @@ class FlxTransitionableState extends FlxState
 		_onExit = OnExit;
 		if (hasTransOut)
 		{
-			if (transitionCamera == null)
-				transitionCamera = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
+			if (transCam == null)
+				transCam = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
 
 			var _trans = createTransition(transOut);
-			_trans.camera = transitionCamera;
+			_trans.camera = transCam;
 			_trans.setStatus(EMPTY);
 			openSubState(_trans);
 

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -71,7 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
-		transCam = null;
+		transCams = null;
 		_onExit = null;
 	}
 

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -1,5 +1,6 @@
 package flixel.addons.transition;
 
+import flixel.FlxCamera;
 import flixel.FlxState;
 
 /**
@@ -35,6 +36,7 @@ class FlxTransitionableState extends FlxState
 
 	public static var skipNextTransIn:Bool = false;
 	public static var skipNextTransOut:Bool = false;
+	public static var transitionCamera:FlxCamera = null;
 
 	// beginning & ending transitions for THIS state:
 	public var transIn:TransitionData;
@@ -69,6 +71,7 @@ class FlxTransitionableState extends FlxState
 		super.destroy();
 		transIn = null;
 		transOut = null;
+		transitionCamera = null;
 		_onExit = null;
 	}
 
@@ -113,8 +116,11 @@ class FlxTransitionableState extends FlxState
 				return;
 			}
 
-			var _trans = createTransition(transIn);
+			if (transitionCamera == null)
+				transitionCamera = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
 
+			var _trans = createTransition(transIn);
+			_trans.camera = transitionCamera;
 			_trans.setStatus(FULL);
 			openSubState(_trans);
 
@@ -131,8 +137,11 @@ class FlxTransitionableState extends FlxState
 		_onExit = OnExit;
 		if (hasTransOut)
 		{
-			var _trans = createTransition(transOut);
+			if (transitionCamera == null)
+				transitionCamera = flixel.FlxG.cameras.list[flixel.FlxG.cameras.list.length - 1];
 
+			var _trans = createTransition(transOut);
+			_trans.camera = transitionCamera;
 			_trans.setStatus(EMPTY);
 			openSubState(_trans);
 


### PR DESCRIPTION
fixes an issue where if you have two (or more) cameras in a state and trigger the transition, the transition only gets drawn in the main camera, never covering the other ones, done by including a variable called `transCam`, which always defaults itself to the highest one in the cameras list