### PR TITLE
Fixed `FlxRuntimeShader` on the latest flixel commit.

### DIFF
--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,10 +1,8 @@
 package flixel.addons.display;
 
-#if nme
-#error "FlxRuntimeShader is not available with nme"
-#elseif flash
-#error "FlxRuntimeShader is not available when targeting flash"
-#else
+#if (FLX_NO_COVERAGE_TEST && (nme || flash))
+#error "FlxRuntimeShader is not available with nme or flash"
+#end
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime
 import lime.utils.Float32Array;
@@ -652,4 +650,3 @@ class FlxRuntimeShader extends FlxGraphicsShader
 		return __glVertexSource = value;
 	}
 }
-#end

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,7 +1,9 @@
 package flixel.addons.display;
 
-#if (FLX_NO_COVERAGE_TEST && (nme || flash))
-#error 'FlxRuntimeShader isn\'t available with nme or flash.'
+#if (nme || flash)
+	#if FLX_NO_COVERAGE_TEST
+	#error "FlxRuntimeShader isn't available with nme or flash."
+	#end
 #else
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,6 +1,10 @@
 package flixel.addons.display;
 
-#if (!nme && !flash)
+#if nme
+    #error "FlxRuntimeShader is not available with nme"
+#elseif flash
+    #error "FlxRuntimeShader is not available when targeting flash"
+#else
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime
 import lime.utils.Float32Array;

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,6 +1,6 @@
 package flixel.addons.display;
 
-#if (FLX_DRAW_QUADS && !flash)
+#if (!nme && !flash)
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime
 import lime.utils.Float32Array;

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,9 +1,9 @@
 package flixel.addons.display;
 
 #if nme
-    #error "FlxRuntimeShader is not available with nme"
+#error "FlxRuntimeShader is not available with nme"
 #elseif flash
-    #error "FlxRuntimeShader is not available when targeting flash"
+#error "FlxRuntimeShader is not available when targeting flash"
 #else
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,8 +1,8 @@
 package flixel.addons.display;
 
 #if (FLX_NO_COVERAGE_TEST && (nme || flash))
-#error "FlxRuntimeShader is not available with nme or flash"
-#end
+#error 'FlxRuntimeShader isn\'t available with nme or flash.'
+#else
 import flixel.graphics.tile.FlxGraphicsShader;
 #if lime
 import lime.utils.Float32Array;
@@ -650,3 +650,4 @@ class FlxRuntimeShader extends FlxGraphicsShader
 		return __glVertexSource = value;
 	}
 }
+#end


### PR DESCRIPTION
On the latest commit in flixel repo, the references to `FLX_DRAW_QUADS` got removed in [this](https://github.com/HaxeFlixel/flixel/commit/5ebdcbb443ca2c0b095c62395cf312b0984269f6) commit and now the define is deprecated, so i made this pr to fix it