### PR TITLE
Fix FlxNestedSprite drawing default png by default

### DIFF
--- a/flixel/addons/display/FlxNestedSprite.hx
+++ b/flixel/addons/display/FlxNestedSprite.hx
@@ -259,7 +259,8 @@ class FlxNestedSprite extends FlxSprite
 
 	override public function draw():Void
 	{
-		super.draw();
+		if(_frame != null) 
+			super.draw();
 
 		for (child in children)
 		{


### PR DESCRIPTION
FlxNestedSprite shows the Flixel default icon when there isn't an image nor graphic loaded which seems to be the default behavior of draw() inherited from FlxSprite. So every FlxNestedSprite that itself doesn't render anything but contains children will have a default icon shown by default.

This PR adresses this problem by guarding the call for drawing of the current FlxNestedSprite with a null check for _frame (the same variable that's used when checking for null when adding the default icon).

Solves #413 