### PR TITLE
Fix plugin warnings

### DIFF
--- a/flixel/addons/nape/FlxNapeSpace.hx
+++ b/flixel/addons/nape/FlxNapeSpace.hx
@@ -64,7 +64,11 @@ class FlxNapeSpace extends FlxBasic
 	 */
 	public static function init():Void
 	{
+		#if (flixel < "5.6.0")
 		FlxG.plugins.add(new FlxNapeSpace());
+		#else
+		FlxG.plugins.addPlugin(new FlxNapeSpace());
+		#end
 
 		if (space == null)
 			space = new Space(new Vec2());


### PR DESCRIPTION
Backwards compatible fix for flixel 5.6.0's deprecation of FlxG.plugin.add