### PR TITLE
Add compatibility checks with flixel

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
 	"[haxe]": {
-		"editor.formatOnSave": true
+		"editor.formatOnSave": true,
+		"editor.formatOnSaveMode": "modifications"
 	}
 }

--- a/flixel/addons/effects/chainable/FlxEffectSprite.hx
+++ b/flixel/addons/effects/chainable/FlxEffectSprite.hx
@@ -1,5 +1,11 @@
 package flixel.addons.effects.chainable;
 
+// TODO: remove this check when min flixel version is 5.6.0,
+// So that FlxAddonDefines will handle this
+#if (flixel < "5.3.0")
+#error "Flixel-Addons is not compatible with flixel versions older than 5.3.0";
+#end
+
 import flixel.FlxCamera;
 import flixel.FlxSprite;
 import flixel.graphics.FlxGraphic;

--- a/flixel/addons/system/macros/FlxAddonDefines.hx
+++ b/flixel/addons/system/macros/FlxAddonDefines.hx
@@ -1,5 +1,6 @@
 package flixel.addons.system.macros;
 
+#if macro
 import haxe.macro.Compiler;
 import haxe.macro.Context;
 import haxe.macro.Expr.Position;
@@ -60,3 +61,4 @@ class FlxAddonDefines
 		Context.fatalError(message, pos);
 	}
 }
+#end

--- a/flixel/addons/system/macros/FlxAddonDefines.hx
+++ b/flixel/addons/system/macros/FlxAddonDefines.hx
@@ -1,0 +1,62 @@
+package flixel.addons.system.macros;
+
+import haxe.macro.Compiler;
+import haxe.macro.Context;
+import haxe.macro.Expr.Position;
+
+// private enum UserAddonDefines {}
+// private enum HelperAddonDefines {}
+
+/**
+ * The purpose of these "defines" classes is mainly to properly communicate version compatibility
+ * among flixel libs, we shouldn't be overly concerned with backwards compatibility, but we do want
+ * to know when a change breaks compatibility between Flixel-Addons and Flixel.
+ * 
+ * @since 3.2.2
+ */
+@:allow(flixel.system.macros.FlxDefines)
+@:access(flixel.system.macros.FlxDefines)
+class FlxAddonDefines
+{
+	/**
+	 * Called from `flixel.system.macros.FlxDefines` on versions 5.6.0 or later
+	 */
+	public static function run()
+	{
+		#if !display
+		checkCompatibility();
+		#end
+	}
+	
+	static function checkCompatibility()
+	{
+		/** this function is only ran in flixel versions 5.6.0 or later, meaning this error will
+		 * never happen. So we've added flixel version checks in the following modules:
+		 * - `FlxEffectSprite`
+		 * - `FlxTypeText`
+		 * - `FlxTransitionableState`
+		 * - `FlxWeapon`
+		 * 
+		 * When the minimum version of flixel is changed to 5.6.0 or greater, remove the above
+		 * checks and this comment.
+		 */
+		#if (flixel < "5.3.0")
+		FlxDefines.abortVersion("Flixel", "5.3.0 or newer", "flixel", (macro null).pos);
+		#end
+	}
+	
+	static function isValidUserDefine(define:Any)
+	{
+		return false;
+	}
+	
+	static function abortVersion(dependency:String, supported:String, found:String, pos:Position)
+	{
+		abort('Flixel-Addons: Unsupported $dependency version! Supported versions are $supported (found ${Context.definedValue(found)}).', pos);
+	}
+	
+	static function abort(message:String, pos:Position)
+	{
+		Context.fatalError(message, pos);
+	}
+}

--- a/flixel/addons/text/FlxTypeText.hx
+++ b/flixel/addons/text/FlxTypeText.hx
@@ -1,5 +1,11 @@
 package flixel.addons.text;
 
+// TODO: remove this check when min flixel version is 5.6.0,
+// So that FlxAddonDefines will handle this
+#if (flixel < "5.3.0")
+#error "Flixel-Addons is not compatible with flixel versions older than 5.3.0";
+#end
+
 import flixel.FlxG;
 import flixel.input.keyboard.FlxKey;
 import flixel.math.FlxMath;

--- a/flixel/addons/transition/FlxTransitionableState.hx
+++ b/flixel/addons/transition/FlxTransitionableState.hx
@@ -1,5 +1,11 @@
 package flixel.addons.transition;
 
+// TODO: remove this check when min flixel version is 5.6.0,
+// So that FlxAddonDefines will handle this
+#if (flixel < "5.3.0")
+#error "Flixel-Addons is not compatible with flixel versions older than 5.3.0";
+#end
+
 import flixel.FlxState;
 
 /**

--- a/flixel/addons/weapon/FlxWeapon.hx
+++ b/flixel/addons/weapon/FlxWeapon.hx
@@ -1,5 +1,11 @@
 package flixel.addons.weapon;
 
+// TODO: remove this check when min flixel version is 5.6.0,
+// So that FlxAddonDefines will handle this
+#if (flixel < "5.3.0")
+#error "Flixel-Addons is not compatible with flixel versions older than 5.3.0";
+#end
+
 import flixel.FlxBasic;
 import flixel.FlxG;
 import flixel.FlxObject;


### PR DESCRIPTION
Add compatibility checks with flixel.

https://github.com/HaxeFlixel/flixel/pull/3001 depends on this

This will allow us to keep track of and communicate version compatibility with flixel. Once https://github.com/HaxeFlixel/setup-flixel v2 is out we will be able to check PRs to flixel-addons against the minimum allowed version of flixel which is currently 5.3.0