### PR TITLE
fix docs

### DIFF
--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,8 +1,10 @@
 package flixel.addons.display;
 
 #if (nme || flash)
-	#if FLX_NO_COVERAGE_TEST
-	#error "FlxRuntimeShader isn't available with nme or flash."
+	// #if (doc-gen)
+		// #warn "FlxRuntimeShader isn't available with nme or flash."
+	#if (FLX_NO_COVERAGE_TEST && !(doc_gen))
+		#error "FlxRuntimeShader isn't available with nme or flash."
 	#end
 #else
 import flixel.graphics.tile.FlxGraphicsShader;

--- a/flixel/addons/display/FlxRuntimeShader.hx
+++ b/flixel/addons/display/FlxRuntimeShader.hx
@@ -1,8 +1,6 @@
 package flixel.addons.display;
 
 #if (nme || flash)
-	// #if (doc-gen)
-		// #warn "FlxRuntimeShader isn't available with nme or flash."
 	#if (FLX_NO_COVERAGE_TEST && !(doc_gen))
 		#error "FlxRuntimeShader isn't available with nme or flash."
 	#end


### PR DESCRIPTION
checks for `doc-gen` compiler flag to avoid errors in flash, for building docs