### PR TITLE
Compatibility with flixel 5.9.0

### DIFF
--- a/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
+++ b/flixel/addons/editors/ogmo/FlxOgmo3Loader.hx
@@ -284,7 +284,11 @@ class FlxOgmo3Loader
 		for (i in 0...tileFlags.length)
 		{
 			var flag = tileFlags[i];
+			#if (flixel < "5.9.0")
 			var specialTile = new FlxTileSpecial(tilemap.getTileByIndex(i), false, false, 0);
+			#else
+			var specialTile = new FlxTileSpecial(tilemap.getTileIndex(i), false, false, 0);
+			#end
 
 			if (flag & 4 > 0)
 				specialTile.flipX = true;

--- a/flixel/addons/tile/FlxRayCastTilemap.hx
+++ b/flixel/addons/tile/FlxRayCastTilemap.hx
@@ -6,6 +6,7 @@ import flixel.math.FlxPoint;
 /**
  * @author greglieberman
  */
+@:deprecated("FlxRayCastTilemap is deprecated, use FlxTilemap.ray or rayStep, instead")// for flixel 5.9.0
 class FlxRayCastTilemap extends FlxTilemap
 {
 	/**
@@ -219,11 +220,6 @@ class FlxRayCastTilemap extends FlxTilemap
 		var X:Int = Std.int((CoordX - x) / scaledTileWidth);
 		var Y:Int = Std.int((CoordY - y) / scaledTileHeight);
 
-		return Y * widthInTiles + X;
-	}
-
-	public function getTileIndex(X:Int, Y:Int):Int
-	{
 		return Y * widthInTiles + X;
 	}
 

--- a/flixel/addons/weapon/FlxWeapon.hx
+++ b/flixel/addons/weapon/FlxWeapon.hx
@@ -430,16 +430,20 @@ class FlxTypedWeapon<TBullet:FlxBullet>
 		}
 	}
 
-	function shouldBulletHit(Object:FlxObject, Bullet:FlxObject):Bool
+	function shouldBulletHit(object:FlxObject, bullet:FlxObject):Bool
 	{
-		if (parent == Object && skipParentCollision)
+		if (parent == object && skipParentCollision)
 		{
 			return false;
 		}
 
-		if ((Object is FlxTilemap))
+		if ((object is FlxTilemap))
 		{
-			return cast(Object, FlxTilemap).overlapsWithCallback(Bullet);
+			#if (flixel < "5.9.0")
+			return cast(object, FlxTilemap).overlapsWithCallback(bullet);
+			#else
+			return cast(object, FlxTilemap).processOverlaps(bullet);
+			#end
 		}
 		else
 		{


### PR DESCRIPTION
- Deprecates `FlxRayCastTilemap` wtf even is this? 
- avoids some deprecated fields, namely FlxBaseTilemap's `getTileByIndex` and `overlapsWithCallback`
- uses the new tilemap method `processOverlaps` instead of `overlapsWithCallback` and uses the new FlxTile features: `orientAt` `overlapsObject`, and `onCollide`