### PR TITLE
Remove deprecation warning on Flixel 5.9.0

### DIFF
--- a/flixel/addons/transition/FlxTransitionSprite.hx
+++ b/flixel/addons/transition/FlxTransitionSprite.hx
@@ -143,7 +143,12 @@ class FlxTransitionSprite extends FlxSprite
 		}
 
 		animation.play(anim);
+		#if (flixel < version("5.9.0"))
 		animation.finishCallback = onFinishAnim;
+		#else
+		if (!animation.onFinish.has(onFinishAnim))
+			animation.onFinish.add(onFinishAnim);
+		#end
 		status = Status;
 	}
 


### PR DESCRIPTION
Makes FlxTransitionSprite use onFinish instead of finishCallback on Flixel 5.9.0

Caused by https://github.com/HaxeFlixel/flixel/pull/3205