### PR TITLE
Add more easily tweakable offsets to `FlxTrail`

### DIFF
--- a/flixel/addons/effects/FlxTrail.hx
+++ b/flixel/addons/effects/FlxTrail.hx
@@ -25,6 +25,11 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 	public var target(default, null):FlxSprite;
 
 	/**
+	 * Useful if you need to have more granular control over per-sprite offsetting.
+	 */
+	public var effectOffset(default, null):FlxPoint = FlxPoint.get();
+
+	/**
 	 * How often to update the trail.
 	 */
 	public var delay:Int;
@@ -164,7 +169,7 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 				spritePosition = FlxPoint.get();
 			}
 
-			spritePosition.set(target.x - target.offset.x, target.y - target.offset.y);
+			spritePosition.set(target.x - target.offset.x - effectOffset.x, target.y - target.offset.y - effectOffset.y);
 			_recentPositions.unshift(spritePosition);
 
 			// Also do the same thing for the Sprites angle if rotationsEnabled


### PR DESCRIPTION
In `FlxTrail` by default it creates a trail behind the target FlxSprite using it's `x/y` position, along with its `offset.x/offset.y` value, to get the general positioning. 

This PR adds an additional variable to `FlxTrail`, `effectOffset` which is a `FlxPoint` to add additional position offsetting to the trail effect. 

This came about in FNF when we changed the way we did animation offset stuff, where we no longer use `offset` to reposition sprites, so the FlxTrail would be in an incorrect position. We fix this by changing the `effectOffset` each frame with our internal offset values.

However I believe this extra variable would be useful otherwise for additional effects, if you want a specific trail sprite to be exaggerated, you can change the offset value every update for example. 