### PR TITLE
FlxTrail code style and organization

### DIFF
--- a/flixel/addons/effects/FlxTrail.hx
+++ b/flixel/addons/effects/FlxTrail.hx
@@ -95,28 +95,28 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 	/**
 	 * Creates a new FlxTrail effect for a specific FlxSprite.
 	 *
-	 * @param	Target		The FlxSprite the trail is attached to.
-	 * @param  	Graphic		The image to use for the trailsprites. Optional, uses the sprite's graphic if null.
-	 * @param	Length		The amount of trailsprites to create.
-	 * @param	Delay		How often to update the trail. 0 updates every frame.
-	 * @param	Alpha		The alpha value for the very first trailsprite.
-	 * @param	Diff		How much lower the alpha of the next trailsprite is.
+	 * @param   target   The FlxSprite the trail is attached to.
+	 * @param   graphic  The image to use for the trailsprites. Optional, uses the sprite's graphic if null.
+	 * @param   length   The amount of trailsprites to create.
+	 * @param   delay    How often to update the trail. 0 updates every frame.
+	 * @param   alpha    The alpha value for the very first trailsprite.
+	 * @param   diff     How much lower the alpha of the next trailsprite is.
 	 */
-	public function new(Target:FlxSprite, ?Graphic:FlxGraphicAsset, Length:Int = 10, Delay:Int = 3, Alpha:Float = 0.4, Diff:Float = 0.05):Void
+	public function new(target:FlxSprite, ?graphic:FlxGraphicAsset, length = 10, delay = 3, alpha = 0.4, diff = 0.05):Void
 	{
 		super();
 
-		_spriteOrigin = FlxPoint.get().copyFrom(Target.origin);
+		_spriteOrigin = FlxPoint.get().copyFrom(target.origin);
 
 		// Sync the vars
-		target = Target;
-		delay = Delay;
-		_graphic = Graphic;
-		_transp = Alpha;
-		_difference = Diff;
+		this.target = target;
+		this.delay = delay;
+		_graphic = graphic;
+		_transp = alpha;
+		_difference = diff;
 
 		// Create the initial trailsprites
-		increaseLength(Length);
+		increaseLength(length);
 		solid = false;
 	}
 
@@ -147,100 +147,94 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 	{
 		// Count the frames
 		_counter++;
-
+		
 		// Update the trail in case the intervall and there actually is one.
 		if (_counter >= delay && _trailLength >= 1)
 		{
 			_counter = 0;
-
-			// Push the current position into the positons array and drop one.
-			var spritePosition:FlxPoint = null;
-			if (_recentPositions.length == _trailLength)
-			{
-				spritePosition = _recentPositions.pop();
-			}
-			else
-			{
-				spritePosition = FlxPoint.get();
-			}
-
-			spritePosition.set(target.x - target.offset.x, target.y - target.offset.y);
-			_recentPositions.unshift(spritePosition);
-
-			// Also do the same thing for the Sprites angle if rotationsEnabled
-			if (rotationsEnabled)
-			{
-				cacheValue(_recentAngles, target.angle);
-			}
-
-			// Again the same thing for Sprites scales if scalesEnabled
-			if (scalesEnabled)
-			{
-				var spriteScale:FlxPoint = null; // sprite.scale;
-				if (_recentScales.length == _trailLength)
-				{
-					spriteScale = _recentScales.pop();
-				}
-				else
-				{
-					spriteScale = FlxPoint.get();
-				}
-
-				spriteScale.set(target.scale.x, target.scale.y);
-				_recentScales.unshift(spriteScale);
-			}
-
-			// Again the same thing for Sprites frames if framesEnabled
-			if (framesEnabled && _graphic == null)
-			{
-				cacheValue(_recentFrames, target.animation.frameIndex);
-				cacheValue(_recentFlipX, target.flipX);
-				cacheValue(_recentFlipY, target.flipY);
-				cacheValue(_recentAnimations, target.animation.curAnim);
-			}
-
+			addTrailFrame();
+			
 			// Now we need to update the all the Trailsprites' values
-			var trailSprite:FlxSprite;
-
-			for (i in 0..._recentPositions.length)
-			{
-				trailSprite = members[i];
-				trailSprite.x = _recentPositions[i].x;
-				trailSprite.y = _recentPositions[i].y;
-
-				// And the angle...
-				if (rotationsEnabled)
-				{
-					trailSprite.angle = _recentAngles[i];
-					trailSprite.origin.x = _spriteOrigin.x;
-					trailSprite.origin.y = _spriteOrigin.y;
-				}
-
-				// the scale...
-				if (scalesEnabled)
-				{
-					trailSprite.scale.x = _recentScales[i].x;
-					trailSprite.scale.y = _recentScales[i].y;
-				}
-
-				// and frame...
-				if (framesEnabled && _graphic == null)
-				{
-					trailSprite.animation.frameIndex = _recentFrames[i];
-					trailSprite.flipX = _recentFlipX[i];
-					trailSprite.flipY = _recentFlipY[i];
-
-					trailSprite.animation.curAnim = _recentAnimations[i];
-				}
-
-				// Is the trailsprite even visible?
-				trailSprite.exists = true;
-			}
+			redrawTrailSprites();
 		}
-
+		
 		super.update(elapsed);
 	}
-
+	
+	inline function recyclePoint(list:Array<FlxPoint>, x:Float, y:Float)
+	{
+		final pos = if (list.length >= _trailLength)
+			list.pop().set(x, y);
+		else
+			FlxPoint.get(x, y);
+		
+		list.unshift(pos);
+	}
+	
+	function addTrailFrame()
+	{
+		// Push the current position into the positons array and drop one.
+		recyclePoint(_recentPositions, target.x - target.offset.x, target.y - target.offset.y);
+		
+		// Also do the same thing for the Sprites angle if rotationsEnabled
+		if (rotationsEnabled)
+		{
+			cacheValue(_recentAngles, target.angle);
+		}
+		
+		// Again the same thing for Sprites scales if scalesEnabled
+		if (scalesEnabled)
+		{
+			recyclePoint(_recentScales, target.scale.x, target.scale.y);
+		}
+		
+		// Again the same thing for Sprites frames if framesEnabled
+		if (framesEnabled && _graphic == null)
+		{
+			cacheValue(_recentFrames, target.animation.frameIndex);
+			cacheValue(_recentFlipX, target.flipX);
+			cacheValue(_recentFlipY, target.flipY);
+			cacheValue(_recentAnimations, target.animation.curAnim);
+		}
+	}
+	
+	function redrawTrailSprites()
+	{
+		for (i in 0..._recentPositions.length)
+		{
+			final trailSprite = members[i];
+			trailSprite.x = _recentPositions[i].x;
+			trailSprite.y = _recentPositions[i].y;
+			
+			// And the angle...
+			if (rotationsEnabled)
+			{
+				trailSprite.angle = _recentAngles[i];
+				trailSprite.origin.x = _spriteOrigin.x;
+				trailSprite.origin.y = _spriteOrigin.y;
+			}
+			
+			// the scale...
+			if (scalesEnabled)
+			{
+				trailSprite.scale.copyFrom(_recentScales[i]);
+			}
+			
+			// and frame...
+			if (framesEnabled && _graphic == null)
+			{
+				trailSprite.animation.frameIndex = _recentFrames[i];
+				trailSprite.flipX = _recentFlipX[i];
+				trailSprite.flipY = _recentFlipY[i];
+				
+				trailSprite.animation.curAnim = _recentAnimations[i];
+			}
+			
+			// Is the trailsprite even visible?
+			trailSprite.exists = true;
+		}
+	}
+	
 	function cacheValue<T>(array:Array<T>, value:T)
 	{
 		array.unshift(value);
@@ -250,13 +244,13 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 
 	public function resetTrail():Void
 	{
-		_recentPositions.splice(0, _recentPositions.length);
-		_recentAngles.splice(0, _recentAngles.length);
-		_recentScales.splice(0, _recentScales.length);
-		_recentFrames.splice(0, _recentFrames.length);
-		_recentFlipX.splice(0, _recentFlipX.length);
-		_recentFlipY.splice(0, _recentFlipY.length);
-		_recentAnimations.splice(0, _recentAnimations.length);
+		FlxDestroyUtil.putArray(_recentPositions);
+		FlxDestroyUtil.putArray(_recentScales);
+		_recentAngles.resize(0);
+		_recentFrames.resize(0);
+		_recentFlipX.resize(0);
+		_recentFlipY.resize(0);
+		_recentAnimations.resize(0);
 
 		for (i in 0...members.length)
 		{
@@ -266,27 +260,27 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 			}
 		}
 	}
-
+	
 	/**
 	 * A function to add a specific number of sprites to the trail to increase its length.
 	 *
-	 * @param 	Amount	The amount of sprites to add to the trail.
+	 * @param   amount  The amount of sprites to add to the trail.
 	 */
-	public function increaseLength(Amount:Int):Void
+	public function increaseLength(amount:Int):Void
 	{
 		// Can't create less than 1 sprite obviously
-		if (Amount <= 0)
+		if (amount <= 0)
 		{
 			return;
 		}
-
-		_trailLength += Amount;
-
+		
+		_trailLength += amount;
+		
 		// Create the trail sprites
-		for (i in 0...Amount)
+		for (i in 0...amount)
 		{
-			var trailSprite = new FlxSprite(0, 0);
-
+			final trailSprite = new FlxSprite(0, 0);
+			
 			if (_graphic == null)
 			{
 				trailSprite.loadGraphicFromSprite(target);
@@ -301,42 +295,42 @@ class FlxTrail extends #if (flixel < "5.7.0") FlxSpriteGroup #else FlxSpriteCont
 			trailSprite.alpha = _transp;
 			_transp -= _difference;
 			trailSprite.solid = solid;
-
+			
 			if (trailSprite.alpha <= 0)
 			{
 				trailSprite.kill();
 			}
 		}
 	}
-
+	
 	/**
 	 * In case you want to change the trailsprite image in runtime...
 	 *
-	 * @param 	Image	The image the sprites should load
+	 * @param  image  The image the sprites should load
 	 */
-	public function changeGraphic(Image:Dynamic):Void
+	public function changeGraphic(image:Dynamic):Void
 	{
-		_graphic = Image;
-
+		_graphic = image;
+		
 		for (i in 0..._trailLength)
 		{
-			members[i].loadGraphic(Image);
+			members[i].loadGraphic(image);
 		}
 	}
 
 	/**
 	 * Handy little function to change which events affect the trail.
 	 *
-	 * @param 	Angle 	Whether the trail reacts to angle changes or not.
-	 * @param 	X 		Whether the trail reacts to x changes or not.
-	 * @param 	Y 		Whether the trail reacts to y changes or not.
-	 * @param	Scale	Wheater the trail reacts to scale changes or not.
+	 * @param   angle  Whether the trail reacts to angle changes or not.
+	 * @param   x      Whether the trail reacts to x changes or not.
+	 * @param   y      Whether the trail reacts to y changes or not.
+	 * @param   scale  Wheater the trail reacts to scale changes or not.
 	 */
-	public function changeValuesEnabled(Angle:Bool, X:Bool = true, Y:Bool = true, Scale:Bool = true):Void
+	public function changeValuesEnabled(angle:Bool, x = true, y = true, scale = true):Void
 	{
-		rotationsEnabled = Angle;
-		xEnabled = X;
-		yEnabled = Y;
-		scalesEnabled = Scale;
+		rotationsEnabled = angle;
+		xEnabled = x;
+		yEnabled = y;
+		scalesEnabled = scale;
 	}
 }


### PR DESCRIPTION
Allows more customization of FlxTrail by separating behavior into separate methods, for instance to accomplish #443
is as simple as:
```hx
class OffsetTrail extends FlxTrail
{
	/**
	 * An offset applied to the target position whenever a new frame is saved.
	 */
	public final frameOffset = FlxPoint.get();
	
	override function addTrailFrame()
	{
		super.addTrailFrame();
		
		_recentPositions[0].addPoint(frameOffset);
	}
	
	override function destroy()
	{
		super.destroy();
		
		frameOffset.put();
	}
}
```