### PR TITLE
fix: add "Point" objectType to TiledObject from Tiled 1.1 update

### DIFF
--- a/flixel/addons/editors/tiled/TiledObject.hx
+++ b/flixel/addons/editors/tiled/TiledObject.hx
@@ -27,6 +27,7 @@ class TiledObject
 	public static inline var POLYGON = 2;
 	public static inline var POLYLINE = 3;
 	public static inline var TILE = 4;
+	public static inline var POINT = 5;
 
 	public var x:Int;
 	public var y:Int;
@@ -147,6 +148,10 @@ class TiledObject
 		{
 			objectType = POLYLINE;
 			getPoints(source.node.polyline);
+		}
+		else if (source.hasNode.point)
+		{
+			objectType = POINT;
 		}
 	}
 


### PR DESCRIPTION
In Tiled 1.1 there was a `Point` object type added.

https://doc.mapeditor.org/en/stable/manual/objects/#insert-point

The changes needed are relatively simple, we just want to set `objectType` so if we do something like
`if (object.objectType == TiledObject.POINT)` it's nice and conveniently there. It doesn't have any extra attributes that isn't already initialized

from my .tmx file
```xml
<object id="5" name="playerStart" x="1195.76" y="697.314">
   <point/>
</object>
```