### PR TITLE
add flixel as a dependency

### DIFF
--- a/haxelib.json
+++ b/haxelib.json
@@ -6,5 +6,8 @@
 	"description": "flixel-addons is a set of useful, additional classes for HaxeFlixel.",
 	"version": "3.3.0",
 	"releasenote": "Compatibility with flixel 5.9.0",
-	"contributors": ["haxeflixel", "Gama11", "GeoKureli"]
+	"contributors": ["haxeflixel", "Gama11", "GeoKureli"],
+	"dependencies": {
+		"flixel": ""
+	}
 }


### PR DESCRIPTION
lime and openfl were added to the base flixel as dependencies so it would make sense to add normal flixel to flixel addons as a dependency