### PR TITLE
Fix Typos in FlxGlitchEffect.hx, FlxWaveEffect.hx, FlxRainbowEffect.hx

### DIFF
--- a/flixel/addons/effects/chainable/FlxGlitchEffect.hx
+++ b/flixel/addons/effects/chainable/FlxGlitchEffect.hx
@@ -59,7 +59,7 @@ class FlxGlitchEffect implements IFlxEffect
 	var _pixels:BitmapData;
 
 	/**
-	 * Creates a new FlxGlitchSprite, which applies a Glitch-distortion effect.
+	 * Creates a new FlxGlitchEffect, which applies a Glitch-distortion effect.
 	 * This effect is non-destructive to the target's pixels, and can be used on animated FlxSprites.
 	 *
 	 * @param	Strength	How strong you want the effect.

--- a/flixel/addons/effects/chainable/FlxRainbowEffect.hx
+++ b/flixel/addons/effects/chainable/FlxRainbowEffect.hx
@@ -54,7 +54,7 @@ class FlxRainbowEffect implements IFlxEffect
 	var _pixels:BitmapData;
 
 	/**
-	 * Creates a new FlxEffectRainbow, which applies a color-cycling effect, using the target's bitmap as a mask.
+	 * Creates a new FlxRainbowEffect, which applies a color-cycling effect, using the target's bitmap as a mask.
 	 *
 	 * @param	Alpha		A number between 0 and 1 to change the opacity of the effect.
 	 * @param	Brightness	A number between 0 and 1, indicating how bright the color should be.

--- a/flixel/addons/effects/chainable/FlxWaveEffect.hx
+++ b/flixel/addons/effects/chainable/FlxWaveEffect.hx
@@ -76,7 +76,7 @@ class FlxWaveEffect implements IFlxEffect
 	var _pixels:BitmapData;
 
 	/**
-	 * Creates a new FlxEffectWave, which applies a wave-distortion effect.
+	 * Creates a new FlxWaveEffect, which applies a wave-distortion effect.
 	 *
 	 * @param	Mode			Which Mode you would like to use for the effect. ALL = applies a constant distortion throughout the image, END = makes the effect get stronger towards the bottom of the image, and START = the reverse of END.
 	 * @param	Strength		How strong you want the effect.


### PR DESCRIPTION
So, I noticed that there were typos after I explored the docs. I don't know if things like 'FlxEffectWave' were intentional or not, lol
Sorry-