### PR TITLE
Fix FlxSlider camera issues

### DIFF
--- a/flixel/addons/ui/FlxSlider.hx
+++ b/flixel/addons/ui/FlxSlider.hx
@@ -271,17 +271,14 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 	override public function update(elapsed:Float):Void
 	{
 		// Clicking and sound logic
-		#if (flixel >= version("5.7.0"))
-		final camera = getCameras()[0];// else use this.camera
-		#end
-		#if (flixel >= version("5.9.0"))
-		final viewX = FlxG.mouse.viewX;
-		final viewY = FlxG.mouse.viewY;
+		#if (flixel >= "5.7.0")
+		final cam = getDefaultCamera();
 		#else
-		final viewX = FlxG.mouse.screenX;
-		final viewY = FlxG.mouse.screenY;
+		final cam = this.camera;
 		#end
-		if (FlxMath.pointInFlxRect(viewX, viewY, _bounds))
+		final mousePosition = FlxG.mouse.getViewPosition(cam);
+		
+		if (FlxMath.pointInFlxRect(mousePosition.x, mousePosition.y, _bounds))
 		{
 			if (hoverAlpha != 1)
 			{
@@ -299,7 +296,7 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 
 			if (FlxG.mouse.pressed)
 			{
-				handle.x = viewX;
+				handle.x = mousePosition.x;
 				updateValue();
 
 				#if FLX_SOUND_SYSTEM
@@ -326,7 +323,7 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 		}
 
 		// Update the target value whenever the slider is being used
-		if ((FlxG.mouse.pressed) && (FlxMath.mouseInFlxRect(false, _bounds)))
+		if ((FlxG.mouse.pressed) && (FlxMath.pointInFlxRect(mousePosition.x, mousePosition.y, _bounds)))
 		{
 			updateValue();
 		}
@@ -345,6 +342,9 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 
 		// Finally, update the valueLabel
 		valueLabel.text = Std.string(FlxMath.roundDecimal(value, decimals));
+
+		mousePosition.put();
+
 
 		super.update(elapsed);
 	}


### PR DESCRIPTION
Whenever a `FlxSlider` is on a different camera, its hitbox is still reliant on `FlxG.camera` causing it to behave incorrectly when `FlxG.camera` zoom is not 1

Here is a example state that shows the issue

```haxe
import flixel.FlxCamera;
import flixel.FlxG;
import flixel.FlxState;
import flixel.addons.ui.FlxSlider;
import flixel.text.FlxText;
import flixel.util.FlxColor;

class PlayState extends FlxState
{
	var text:FlxText;

	var testValue:Float = 1;

	override public function create()
	{
		super.create();

		FlxG.camera.bgColor = FlxColor.GRAY;

		var cam2 = new FlxCamera();
		cam2.bgColor = 0x0;
		FlxG.cameras.add(cam2, false);

		var slider = new FlxSlider(this, 'testValue', 0, 0, 0, 2, 200, 30, 5, FlxColor.WHITE, FlxColor.BLACK);
		add(slider);
		slider.screenCenter();
		slider.cameras = [cam2];

		text = new FlxText(0, 0, 0, '', 16);
		add(text);
		text.cameras = [cam2];
	}

	override public function update(elapsed:Float)
	{
		super.update(elapsed);

		if (FlxG.keys.pressed.LEFT)
			FlxG.camera.zoom -= 0.2 * elapsed;
		if (FlxG.keys.pressed.RIGHT)
			FlxG.camera.zoom += 0.2 * elapsed;

		text.text = 'zoom: ' + Std.string(FlxG.camera.zoom);
	}
}
```
Also here is a video showing the issue 

https://github.com/user-attachments/assets/661d2917-e3ca-4126-8428-7c6c31d74730



