### PR TITLE
FlxGridOverlay: Prevent freeze when passing invalid cell size values

### DIFF
--- a/flixel/addons/display/FlxGridOverlay.hx
+++ b/flixel/addons/display/FlxGridOverlay.hx
@@ -44,10 +44,11 @@ class FlxGridOverlay
 			Height = FlxG.height;
 		}
 
-		if (Width < CellWidth || Height < CellHeight || CellWidth <= 0 || CellHeight <= 0)
-		{
-			return null;
-		}
+		if (Width < CellWidth || Height < CellHeight)
+			throw "The width and height of a grid cannot be smaller than the cell's width and height!";
+
+		if (CellWidth <= 0 || CellHeight <= 0)
+			throw "Grid cell width/height cannot be less or equal to 0";
 
 		var grid:BitmapData = createGrid(CellWidth, CellHeight, Width, Height, Alternate, Color1, Color2);
 
@@ -89,10 +90,11 @@ class FlxGridOverlay
 			Height = FlxG.height;
 		}
 
-		if (Width < CellWidth || Height < CellHeight || CellWidth <= 0 || CellHeight <= 0)
-		{
-			return null;
-		}
+		if (Width < CellWidth || Height < CellHeight)
+			throw "The width and height of a grid cannot be smaller than the cell's width and height!";
+
+		if (CellWidth <= 0 || CellHeight <= 0)
+			throw "Grid cell width/height cannot be less or equal to 0";
 
 		var grid:BitmapData = createGrid(CellWidth, CellHeight, Width, Height, Alternate, Color1, Color2);
 		Sprite.pixels.copyPixels(grid, new Rectangle(0, 0, Width, Height), new Point(0, 0), null, null, true);

--- a/flixel/addons/display/FlxGridOverlay.hx
+++ b/flixel/addons/display/FlxGridOverlay.hx
@@ -44,7 +44,7 @@ class FlxGridOverlay
 			Height = FlxG.height;
 		}
 
-		if (Width < CellWidth || Height < CellHeight)
+		if (Width < CellWidth || Height < CellHeight || CellWidth <= 0 || CellHeight <= 0)
 		{
 			return null;
 		}
@@ -89,7 +89,7 @@ class FlxGridOverlay
 			Height = FlxG.height;
 		}
 
-		if (Width < CellWidth || Height < CellHeight)
+		if (Width < CellWidth || Height < CellHeight || CellWidth <= 0 || CellHeight <= 0)
 		{
 			return null;
 		}

--- a/flixel/addons/display/FlxGridOverlay.hx
+++ b/flixel/addons/display/FlxGridOverlay.hx
@@ -22,10 +22,10 @@ class FlxGridOverlay
 	 * If false each row will be the same colour, creating a striped-pattern effect.
 	 * So to create an 8x8 grid you'd call create(8,8)
 	 *
-	 * @param	CellWidth		The grid cell width
-	 * @param	CellHeight		The grid cell height
-	 * @param	Width			The width of the FlxSprite. If -1 it will be the size of the game (FlxG.width)
-	 * @param	Height			The height of the FlxSprite. If -1 it will be the size of the game (FlxG.height)
+	 * @param	CellWidth		The grid cell width. Must be greater than 0.
+	 * @param	CellHeight		The grid cell height. Must be greater than 0.
+	 * @param	Width			The width of the FlxSprite. If -1 it will be the size of the game (FlxG.width). This value cannot be smaller than the `CellWidth`
+	 * @param	Height			The height of the FlxSprite. If -1 it will be the size of the game (FlxG.height). This value cannot be smaller than the `CellHeight`
 	 * @param	Alternate		Should the pattern alternate on each new row? Default true = checkerboard effect. False = vertical stripes
 	 * @param	Color1			The first fill colour in 0xAARRGGBB format
 	 * @param	Color2			The second fill colour in 0xAARRGGBB format
@@ -68,10 +68,10 @@ class FlxGridOverlay
 	 * So to create an 8x8 grid you'd call create(8,8,
 	 *
 	 * @param	Sprite			The FlxSprite you wish to draw the grid on-top of. This updates its pixels value, not just the current frame (don't use animated sprites!)
-	 * @param	CellWidth		The grid cell width
-	 * @param	CellHeight		The grid cell height
-	 * @param	Width			The width of the FlxSprite. If -1 it will be the size of the game (FlxG.width)
-	 * @param	Height			The height of the FlxSprite. If -1 it will be the size of the game (FlxG.height)
+	 * @param	CellWidth		The grid cell width. Must be greater than 0.
+	 * @param	CellHeight		The grid cell height. Must be greater than 0.
+	 * @param	Width			The width of the FlxSprite. If -1 it will be the size of the game (FlxG.width). This value cannot be smaller than the `CellWidth`
+	 * @param	Height			The height of the FlxSprite. If -1 it will be the size of the game (FlxG.height). This value cannot be smaller than the `CellHeight`
 	 * @param	Alternate		Should the pattern alternate on each new row? Default true = checkerboard effect. False = vertical stripes
 	 * @param	Color1			The first fill colour in 0xAARRGGBB format
 	 * @param	Color2			The second fill colour in 0xAARRGGBB format


### PR DESCRIPTION
Passing in 0 or a negative number (in my case due to a bad calculation) when creating a grid overlay caused the while loops in `createGrid()` to never exit because x/y would always be smaller than width/height

https://github.com/HaxeFlixel/flixel-addons/blob/cff2640a6db35544eb3faf3655de5e57a709cc2a/flixel/addons/display/FlxGridOverlay.hx#L112