### PR TITLE
Modifying FlxStarfield and FlxStarfield2D

### DIFF
--- a/flixel/addons/display/FlxStarField.hx
+++ b/flixel/addons/display/FlxStarField.hx
@@ -138,6 +138,16 @@ class FlxStarField3D extends FlxStarField
 
 		super.update(elapsed);
 	}
+
+	/**
+	 * Change the central point that stars move out from. When you want the stars to generate from a point other than the center of the screen.
+	 *
+	 * @param	Point		The point reference to change the central point of the stars.
+	 */
+	public function setCenter(point:FlxPoint):Void
+	{
+		center = point;
+	}
 }
 
 /**


### PR DESCRIPTION
Modifying FlxStarfield and FlxStarfield2D to Utilize a 0 speed for static starfield. 

I needed a version of Starfield with stationary stars. So I modified Starfield and Starfield2d to accommodate for a static field by setting the starspeed to 0, specifically, the max speed. 

When creating a new Starfield2D, just set the speed to 0:
`var stars = new FlxStarField2D();
stars.setStarSpeed(0,0);`

The FlxStarfield and FlxStarfield2D then check if the speed is 0 and if so, it does not move the stars. It retains the ability for the stars to twinkle by setting a FlxG.random.float(0,1) in the FlxStarfield.draw function when assigning the colorIndex.
