### PR TITLE
FlxEffectSprite and FlxTilemapExt: Fix more deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### 4.0.1 (December 6, 2025)
+- `FlxTilemapExt` and `FlxEffectSprite`: Fix deprecation warnings ([#473](https://github.com/HaxeFlixel/flixel/pull/473))
+
 # 4.0.0 (December 6, 2025)
 Removed deprecated classes
 - `FlxRayCastTilemap`: `FlxBaseTilemap` has an all-around better `ray()` method ([#455](https://github.com/HaxeFlixel/flixel-addons/pull/455))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 ### 4.0.1 (December 6, 2025)
+
+#### Changes and improvements:
 - `FlxTilemapExt` and `FlxEffectSprite`: Fix deprecation warnings ([#473](https://github.com/HaxeFlixel/flixel/pull/473))
 
 # 4.0.0 (December 6, 2025)
-Removed deprecated classes
+
+#### Removed deprecated classes
 - `FlxRayCastTilemap`: `FlxBaseTilemap` has an all-around better `ray()` method ([#455](https://github.com/HaxeFlixel/flixel-addons/pull/455))
 - `FlxMouseControl`: Use `FlxMouseEvent`, instead ([#455](https://github.com/HaxeFlixel/flixel-addons/pull/455))
 

--- a/flixel/addons/effects/chainable/FlxEffectSprite.hx
+++ b/flixel/addons/effects/chainable/FlxEffectSprite.hx
@@ -88,7 +88,7 @@ class FlxEffectSprite extends FlxSprite
 	 */
 	override public function getScreenPosition(?point:FlxPoint, ?Camera:FlxCamera):FlxPoint
 	{
-		return super.getScreenPosition(point, Camera).addPoint(_effectOffset);
+		return super.getScreenPosition(point, Camera).add(_effectOffset.x, _effectOffset.y);
 	}
 
 	override public function draw():Void
@@ -124,7 +124,7 @@ class FlxEffectSprite extends FlxSprite
 					pixels = effect.apply(pixels);
 					if (effect.offset != null)
 					{
-						_effectOffset.addPoint(effect.offset);
+						_effectOffset.add(effect.offset.x, effect.offset.y);
 					}
 				}
 			}

--- a/flixel/addons/tile/FlxTilemapExt.hx
+++ b/flixel/addons/tile/FlxTilemapExt.hx
@@ -1,6 +1,5 @@
 package flixel.addons.tile;
 
-import openfl.display.BitmapData;
 import flixel.FlxCamera;
 import flixel.FlxG;
 import flixel.FlxObject;
@@ -15,6 +14,7 @@ import flixel.tile.FlxTilemap;
 import flixel.tile.FlxTilemapBuffer;
 import flixel.util.FlxDestroyUtil;
 import flixel.util.FlxDirectionFlags;
+import openfl.display.BitmapData;
 
 using flixel.util.FlxColorTransformUtil;
 
@@ -126,8 +126,9 @@ class FlxTilemapExt extends FlxTilemap
 		}
 		else
 		{
-			getScreenPosition(_point, camera).subtractPoint(offset).copyToFlash(_helperPoint);
-
+			getScreenPosition(_point, camera);
+			_helperPoint.setTo(_point.x + offset.x, _point.y + offset.y);
+			
 			_helperPoint.x = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.x) : _helperPoint.x;
 			_helperPoint.y = isPixelPerfectRender(camera) ? Math.floor(_helperPoint.y) : _helperPoint.y;
 

--- a/haxelib.json
+++ b/haxelib.json
@@ -4,8 +4,8 @@
 	"license": "MIT",
 	"tags": ["game", "openfl", "flash", "neko", "cpp", "android", "ios", "cross"],
 	"description": "flixel-addons is a set of useful, additional classes for HaxeFlixel.",
-	"version": "4.0.0",
-	"releasenote": "Remove deprecated FlxRayCastTilemap and FlxMouseControl",
+	"version": "4.0.1",
+	"releasenote": "Fix more deprecation warnings",
 	"contributors": ["haxeflixel", "Gama11", "GeoKureli"],
 	"dependencies": {
 		"flixel": ""


### PR DESCRIPTION
Remove refs to `addPoint`, `substractPoint` and `copyToFlash`