### PR TITLE
FlxSlider: replace set() calls with zero()

### DIFF
--- a/flixel/addons/ui/FlxSlider.hx
+++ b/flixel/addons/ui/FlxSlider.hx
@@ -229,35 +229,35 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 		body = new FlxSprite(offset.x, offset.y);
 		var colorKey:String = "slider:W=" + _width + "H=" + _height + "C=" + _color.toHexString() + "T=" + _thickness;
 		body.makeGraphic(_width, _height, 0, false, colorKey);
-		body.scrollFactor.set();
+		body.scrollFactor.zero();
 		FlxSpriteUtil.drawLine(body, 0, _height / 2, _width, _height / 2, {color: _color, thickness: _thickness});
 
 		handle = new FlxSprite(offset.x, offset.y);
 		handle.makeGraphic(_thickness, _height, _handleColor);
-		handle.scrollFactor.set();
+		handle.scrollFactor.zero();
 
 		// Creating the texts
 		nameLabel = new FlxText(offset.x, 0, _width, varString);
 		nameLabel.alignment = "center";
 		nameLabel.color = _color;
-		nameLabel.scrollFactor.set();
+		nameLabel.scrollFactor.zero();
 
 		var textOffset:Float = _height + offset.y + 3;
 
 		valueLabel = new FlxText(offset.x, textOffset, _width);
 		valueLabel.alignment = "center";
 		valueLabel.color = _handleColor;
-		valueLabel.scrollFactor.set();
+		valueLabel.scrollFactor.zero();
 
 		minLabel = new FlxText(-50 + offset.x, textOffset, 100, Std.string(minValue));
 		minLabel.alignment = "center";
 		minLabel.color = _color;
-		minLabel.scrollFactor.set();
+		minLabel.scrollFactor.zero();
 
 		maxLabel = new FlxText(_width - 50 + offset.x, textOffset, 100, Std.string(maxValue));
 		maxLabel.alignment = "center";
 		maxLabel.color = _color;
-		maxLabel.scrollFactor.set();
+		maxLabel.scrollFactor.zero();
 
 		// Add all the objects
 		add(body);


### PR DESCRIPTION
`set()` with no args may be deprecated, but even if it is not, zero() is more clear