### PR TITLE
Improve FlxSlider dragging

### DIFF
--- a/flixel/addons/ui/FlxSlider.hx
+++ b/flixel/addons/ui/FlxSlider.hx
@@ -111,6 +111,11 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 	public var varString(default, set):String;
 
 	/**
+		Whether the slider is currently being dragged
+	**/
+	public var dragging:Bool = false;
+
+	/**
 	 * The dragable area for the handle. Is configured automatically.
 	 */
 	var _bounds:FlxRect;
@@ -153,11 +158,6 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 	 * Helper var for callbacks.
 	 */
 	var _lastPos:Float;
-
-	/**
-	 * Helper variable to avoid the clickSound playing every frame.
-	 */
-	var _justClicked:Bool = false;
 
 	/**
 	 * Helper variable to avoid the hoverSound playing every frame.
@@ -294,22 +294,16 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 
 			_justHovered = true;
 
-			if (FlxG.mouse.pressed)
+			if (FlxG.mouse.justPressed)
 			{
-				handle.x = mousePosition.x;
-				updateValue();
-
+				dragging = true;
+			
 				#if FLX_SOUND_SYSTEM
-				if (clickSound != null && !_justClicked)
+				if (clickSound != null)
 				{
 					FlxG.sound.play(clickSound);
-					_justClicked = true;
 				}
 				#end
-			}
-			if (!FlxG.mouse.pressed)
-			{
-				_justClicked = false;
 			}
 		}
 		else
@@ -322,9 +316,13 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 			_justHovered = false;
 		}
 
-		// Update the target value whenever the slider is being used
-		if ((FlxG.mouse.pressed) && (FlxMath.pointInFlxRect(mousePosition.x, mousePosition.y, _bounds)))
+		if (dragging)
 		{
+			if (FlxG.mouse.pressed)
+				handle.x = mousePosition.x;
+			else
+				dragging = false;
+			
 			updateValue();
 		}
 
@@ -356,9 +354,11 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 	{
 		if (_lastPos != relativePos)
 		{
+			value = (relativePos * (maxValue - minValue)) + minValue;
+
 			if ((setVariable) && (varString != null))
 			{
-				Reflect.setProperty(_object, varString, (relativePos * (maxValue - minValue)) + minValue);
+				Reflect.setProperty(_object, varString, value);
 			}
 
 			_lastPos = relativePos;
@@ -466,6 +466,11 @@ class FlxSlider extends #if (flixel < version("5.7.0")) FlxSpriteGroup #else Flx
 		if (pos > 1)
 		{
 			pos = 1;
+		}
+		// Relative position can't be smaller than 0
+		else if (pos < 0)
+		{
+			pos = 0;
 		}
 
 		return pos;


### PR DESCRIPTION
Currently, just moving the mouse over an FlxSlider while holding left click moves the slider, which can be a bit annoying.  

Similarly, the slider only moves if you're hovering over it, which *sounds* correct but it makes moving the slider to the min/max difficult if the framerate is low or if you do it fast enough.

Unrelated to the above, FlxSlider requires an object and is unusable without one, considering you can give it a callback I think this shouldn't be necessary :>

Here's a demonstration of all of the mentioned issues: 

https://github.com/user-attachments/assets/0996fffd-e02c-41cb-ab4c-d309c6a45096

And here's how FlxSlider behaves with the changes I made:

https://github.com/user-attachments/assets/cbdfa2e3-2388-468e-88e9-3b6dfe372b02

Plus the test code I used, just in case :>

```hx
import flixel.FlxG;
import flixel.FlxState;
import flixel.addons.ui.FlxSlider;
import flixel.text.FlxText;

class BubState extends FlxState {
	var mouseStatusTxt:FlxText;

	override function create() {
		super.create();

		FlxG.camera.bgColor = 0xFFAAAAAA;
		var obj = {v1: 0.0, v2: 0.0, v3: 0.0};
		add(new FlxSlider(obj, "v1", 100, 50)); 
		add(new FlxSlider(obj, "v2", 100, 150)); 
		add(new FlxSlider(obj, "v3", 100, 250));
		add(new FlxSlider(null, "null object", 300, 250));

		mouseStatusTxt = new FlxText();
		mouseStatusTxt.color = 0xFF000000;
		add(mouseStatusTxt);
	}

	override function update(elapsed:Float) {
		mouseStatusTxt.text = FlxG.mouse.pressed ? "LEFT CLICK PRESSED" : "";
		super.update(elapsed);
	}
}
```